### PR TITLE
Fixed key in X-MICROSOFT-CDO-TZID mapping

### DIFF
--- a/lib/Sabre/VObject/TimeZoneUtil.php
+++ b/lib/Sabre/VObject/TimeZoneUtil.php
@@ -266,7 +266,7 @@ class TimeZoneUtil {
         30 => 'America/Noronha',
          8 => 'America/Sao_Paulo', // Best guess
         32 => 'America/Argentina/Buenos_Aires',
-        69 => 'America/Godthab',
+        60 => 'America/Godthab',
         28 => 'America/St_Johns',
          9 => 'America/Halifax',
         33 => 'America/Caracas',


### PR DESCRIPTION
- 69 is already defined (correctly) for Africa/Luanda
- correct X-MICROSOFT-CDO-TZID for Greenland is 60
