### PR TITLE
Escape , and ; from property values as per RFC2445

### DIFF
--- a/lib/Sabre/VObject/Property.php
+++ b/lib/Sabre/VObject/Property.php
@@ -176,10 +176,14 @@ class Property extends Node {
         $src = array(
             '\\',
             "\n",
+            ';',
+            ',',
         );
         $out = array(
             '\\\\',
             '\n',
+            '\;',
+            '\,',
         );
         $str.=':' . str_replace($src, $out, $this->value);
 


### PR DESCRIPTION
The RFC specifies that \, \n, ; and , are all characters to be escaped from icalendar values
See here http://tools.ietf.org/html/draft-ietf-calsify-rfc2445bis-08#section-3.3.11

Thanks
