### PR TITLE
vCard parser cannot read multiple vCards separated with more than one line break

### DIFF
--- a/lib/Sabre/VObject/Parser/MimeDir.php
+++ b/lib/Sabre/VObject/Parser/MimeDir.php
@@ -212,6 +212,7 @@ class MimeDir extends Parser {
      *
      * This method strips any newlines and also takes care of unfolding.
      *
+     * @throws \Sabre\VObject\EofException
      * @return string
      */
     protected function readLine() {
@@ -225,8 +226,8 @@ class MimeDir extends Parser {
                 if ($rawLine === false && feof($this->input)) {
                     throw new EofException('End of document reached prematurely');
                 }
-            } while ($rawLine===''); // Skipping empty lines
-            $rawLine = rtrim($rawLine, "\r\n");
+                $rawLine = rtrim($rawLine, "\r\n");
+            } while ($rawLine === ''); // Skipping empty lines
             $this->lineIndex++;
         }
         $line = $rawLine;
@@ -234,7 +235,7 @@ class MimeDir extends Parser {
         $this->startLine = $this->lineIndex;
 
         // Looking ahead for folded lines.
-        while(true) {
+        while (true) {
 
             $nextLine = rtrim(fgets($this->input), "\r\n");
             $this->lineIndex++;
@@ -242,8 +243,8 @@ class MimeDir extends Parser {
                 break;
             }
             if ($nextLine[0] === "\t" || $nextLine[0] === " ") {
-                $line.=substr($nextLine,1);
-                $rawLine.="\n " . substr($nextLine,1);
+                $line .= substr($nextLine, 1);
+                $rawLine .= "\n " . substr($nextLine, 1);
             } else {
                 $this->lineBuffer = $nextLine;
                 break;

--- a/tests/Sabre/VObject/Splitter/VCardTest.php
+++ b/tests/Sabre/VObject/Splitter/VCardTest.php
@@ -81,7 +81,7 @@ EOT;
     }
 
     /**
-     * @expectedException \Sabre\VObject\ParseException 
+     * @expectedException \Sabre\VObject\ParseException
      */
     function testVCardImportCheckInvalidArgumentException() {
         $data = <<<EOT
@@ -114,6 +114,29 @@ EOT;
         }
         $this->assertEquals(2, $count);
 
+    }
+
+    function testImportMultipleSeparatedWithNewLines() {
+        $data = <<<EOT
+BEGIN:VCARD
+UID:foo
+END:VCARD
+
+
+BEGIN:VCARD
+UID:foo
+END:VCARD
+
+
+EOT;
+        $tempFile = $this->createStream($data);
+        $objects = new VCard($tempFile);
+
+        $count = 0;
+        while ($objects->getNext()) {
+            $count++;
+        }
+        $this->assertEquals(2, $count);
     }
 
     function testVCardImportVCardWithoutUID() {


### PR DESCRIPTION
If multiple vCards in one file are separated with two line breaks, exception is thrown even if vCards are correct.
