### PR TITLE
Fix double-escaping of , and ; in compound properties

### DIFF
--- a/lib/Sabre/VObject/Property.php
+++ b/lib/Sabre/VObject/Property.php
@@ -195,6 +195,15 @@ class Property extends Node {
             '\n',
             '',
         );
+
+        // avoid double-escaping of \, and \; from Compound properties
+        if (method_exists($this, 'setParts')) {
+            $src[] = '\\\\,';
+            $out[] = '\\,';
+            $src[] = '\\\\;';
+            $out[] = '\\;';
+        }
+
         $str.=':' . str_replace($src, $out, $this->value);
 
         $out = '';


### PR DESCRIPTION
I found a bug in the 2.1 version of the library where commas and semicolons get double-escaped in combination of `Property\Compound::setParts()` and `Property::serialize()`. Thus for example ADR properties with commas get wrongly encoded like this:

```
ADR;TYPE=HOME:;;Street\\, Some;City\\, The;;123456;
```

Although I'm not sure if that's the perfect way to fix this issue, it works for me.
