### PR TITLE
Catch exceptions from invalid recurrence exception dates.

### DIFF
--- a/lib/Sabre/VObject/RecurrenceIterator.php
+++ b/lib/Sabre/VObject/RecurrenceIterator.php
@@ -464,8 +464,11 @@ class RecurrenceIterator implements \Iterator {
 
                 foreach(explode(',', (string)$exDate) as $exceptionDate) {
 
-                    $this->exceptionDates[] =
-                        DateTimeParser::parse($exceptionDate, $this->startDate->getTimeZone());
+                    try {
+                        $this->exceptionDates[] =
+                            DateTimeParser::parse($exceptionDate, $this->startDate->getTimeZone());
+                    } catch (Exception $e) {
+                    }
 
                 }
 


### PR DESCRIPTION
If a client sends an invalid date with an EXDATE attribute, parsing all incoming objects fails.
