### PR TITLE
Fix empty DTSTART

### DIFF
--- a/lib/Sabre/VObject/Component/VEvent.php
+++ b/lib/Sabre/VObject/Component/VEvent.php
@@ -41,6 +41,11 @@ class VEvent extends VObject\Component {
 
         }
 
+        if(!$this->DTSTART instanceof VObject\Property\ICalendar\DateTime) {
+            $dateStamp = $this->DTSTAMP->getDateTime();
+            return (($start <= $dateStamp) && ($end > $dateStamp));
+        }
+
         $effectiveStart = $this->DTSTART->getDateTime();
         if (isset($this->DTEND)) {
 


### PR DESCRIPTION
If you try expand calendar object, with simple event like:

```
BEGIN:VEVENT
DTSTAMP:20130101T000000Z
UID:xxxxxxx-xxx-xxxx-xxxxxxx
END:VEVENT
```

you get error `Call to a member function getDateTime() on a non-object in ...lib/Sabre/VObject/Component/VEvent.php:52`

This commit fix it.
