### PR TITLE
Fix FreeBusyGenerator doc, use getResult() instead of result()

### DIFF
--- a/doc/usage_3.md
+++ b/doc/usage_3.md
@@ -480,7 +480,7 @@ $fbGenerator = new VObject\FreeBusyGenerator(
 );
 
 // Grabbing the report
-$freebusy = $fbGenerator->result();
+$freebusy = $fbGenerator->getResult();
 
 // The freebusy report is another VCALENDAR object, so we can serialize it as usual:
 echo $freebusy->serialize();


### PR DESCRIPTION
Fix FreeBusyGenerator doc, use getResult() instead of result()
