### PR TITLE
Reader: fix an infinite loop from passing an invalid argument

### DIFF
--- a/lib/Sabre/VObject/Parser/MimeDir.php
+++ b/lib/Sabre/VObject/Parser/MimeDir.php
@@ -229,7 +229,7 @@ class MimeDir extends Parser {
         } else {
             do {
                 $rawLine = fgets($this->input);
-                if ($rawLine === false && feof($this->input)) {
+                if ($rawLine === false || feof($this->input)) {
                     throw new EofException('End of document reached prematurely');
                 }
                 $rawLine = rtrim($rawLine, "\r\n");


### PR DESCRIPTION
Reader: fix an infinite loop from passing an invalid argument

``` php
<?php
$ics = file_get_contents('file-that-doesnt-exists.ics');
$cal = VObject\Reader::read($ics);
```
