### PR TITLE
Add lookup to bin parent directory for autoloader.

### DIFF
--- a/bin/vobject
+++ b/bin/vobject
@@ -6,6 +6,7 @@ namespace Sabre\VObject;
 // This sucks.. we have to try to find the composer autoloader. But chances
 // are, we can't find it this way. So we'll do our bestest
 $paths = array(
+    __DIR__ . '/../autoload.php',
     __DIR__ . '/../vendor/autoload.php',  // In case vobject is cloned directly
     __DIR__ . '/../../../autoload.php',   // In case vobject is a composer dependency.
 );


### PR DESCRIPTION
In my `composer.json` file I have a custom `vendor-dir` defined:

```
"config": {
        "vendor-dir": "Sources/Classes/ThirdParty/"
}
```

This installs vobject in `Sources/Classes/ThirdParty/bin`
with the autoloader being located in `Sources/Classes/ThirdParty`

so when `vobject` is called, it can't find the autoloader based on the current code.  It should also look at the `bin` parent directory as well.
