### PR TITLE
Fix comment for phpcs

### DIFF
--- a/lib/Sabre/VObject/timezonedata/php-compat.php
+++ b/lib/Sabre/VObject/timezonedata/php-compat.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * A list of PHP timezones that were supported in PHP 5.5.9, but are no longer 
+ * A list of PHP timezones that were supported in PHP 5.5.9, but are no longer
  * in PHP 5.5.10.
  *
  * Some more info here:


### PR DESCRIPTION
The latest stable version of phpcs (1.5.3) doesn’t find any error, but
the latest alpha (2.0.0a2) does. This change has been automatically
made by PHPCBF.
