### PR TITLE
keep time & timezone information for recurring events, fix for #101

### DIFF
--- a/lib/Sabre/VObject/RecurrenceIterator.php
+++ b/lib/Sabre/VObject/RecurrenceIterator.php
@@ -905,7 +905,7 @@ class RecurrenceIterator implements \Iterator {
             // This line does not currently work in hhvm. Temporary workaround
             // follows:
             // $this->currentDate->modify('first day of this month');
-            $this->currentDate = new \DateTime($this->currentDate->format('Y-m-1'));
+            $this->currentDate = new \DateTime($this->currentDate->format('Y-m-1 H:i:s'), $this->currentDate->getTimezone());
             // end of workaround
             $this->currentDate->modify('+ ' . $this->interval . ' months');
 


### PR DESCRIPTION
Maintaining the time & timezone information when creating the new DateTime-object solves #101, excluded dates will be filtered out correctly.

(And sorry, just realising I could/should have added the issue description in this pull request and not open two...)
