### PR TITLE
PHP 5.6.1 restored EST5EDT

### DIFF
--- a/tests/Sabre/VObject/TimeZoneUtilTest.php
+++ b/tests/Sabre/VObject/TimeZoneUtilTest.php
@@ -294,7 +294,7 @@ END:VCALENDAR
 HI;
 
         $tz = TimeZoneUtil::getTimeZone('/freeassociation.sourceforge.net/Tzfile/SystemV/EST5EDT', Reader::read($vobj), true);
-        if (version_compare(PHP_VERSION, '5.5.10', '>=')) {
+        if (version_compare(PHP_VERSION, '5.5.10', '>=') and version_compare(PHP_VERSION, '5.6.1', '<=')) {
             $ex = new \DateTimeZone('America/New_York');
         } else {
             $ex = new \DateTimeZone('EST5EDT');


### PR DESCRIPTION
The tests fail with PHP 5.6.1 and 5.6.2 without this “fix”.
