### PR TITLE
Simplify by extending ArrayIterator.

### DIFF
--- a/lib/ElementList.php
+++ b/lib/ElementList.php
@@ -2,6 +2,10 @@
 
 namespace Sabre\VObject;
 
+use
+    ArrayIterator,
+    LogicException;
+
 /**
  * VObject ElementList
  *
@@ -12,133 +16,10 @@ namespace Sabre\VObject;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ElementList implements \Iterator, \Countable, \ArrayAccess {
+class ElementList extends ArrayIterator {
 
-    /**
-     * Inner elements
-     *
-     * @var array
-     */
-    protected $elements = [];
-
-    /**
-     * Creates the element list.
-     *
-     * @param array $elements
-     */
-    function __construct(array $elements) {
-
-        $this->elements = $elements;
-
-    }
-
-    /* {{{ Iterator interface */
-
-    /**
-     * Current position
-     *
-     * @var int
-     */
-    private $key = 0;
-
-    /**
-     * Returns current item in iteration
-     *
-     * @return Element
-     */
-    function current() {
-
-        return $this->elements[$this->key];
-
-    }
-
-    /**
-     * To the next item in the iterator
-     *
-     * @return void
-     */
-    function next() {
-
-        $this->key++;
-
-    }
-
-    /**
-     * Returns the current iterator key
-     *
-     * @return int
-     */
-    function key() {
-
-        return $this->key;
-
-    }
-
-    /**
-     * Returns true if the current position in the iterator is a valid one
-     *
-     * @return bool
-     */
-    function valid() {
-
-        return isset($this->elements[$this->key]);
-
-    }
-
-    /**
-     * Rewinds the iterator
-     *
-     * @return void
-     */
-    function rewind() {
-
-        $this->key = 0;
-
-    }
-
-    /* }}} */
-
-    /* {{{ Countable interface */
-
-    /**
-     * Returns the number of elements
-     *
-     * @return int
-     */
-    function count() {
-
-        return count($this->elements);
-
-    }
-
-    /* }}} */
 
     /* {{{ ArrayAccess Interface */
-
-
-    /**
-     * Checks if an item exists through ArrayAccess.
-     *
-     * @param int $offset
-     * @return bool
-     */
-    function offsetExists($offset) {
-
-        return isset($this->elements[$offset]);
-
-    }
-
-    /**
-     * Gets an item through ArrayAccess.
-     *
-     * @param int $offset
-     * @return mixed
-     */
-    function offsetGet($offset) {
-
-        return $this->elements[$offset];
-
-    }
 
     /**
      * Sets an item through ArrayAccess.
@@ -149,7 +30,7 @@ class ElementList implements \Iterator, \Countable, \ArrayAccess {
      */
     function offsetSet($offset, $value) {
 
-        throw new \LogicException('You can not add new objects to an ElementList');
+        throw new LogicException('You can not add new objects to an ElementList');
 
     }
 
@@ -163,7 +44,7 @@ class ElementList implements \Iterator, \Countable, \ArrayAccess {
      */
     function offsetUnset($offset) {
 
-        throw new \LogicException('You can not remove objects from an ElementList');
+        throw new LogicException('You can not remove objects from an ElementList');
 
     }
 


### PR DESCRIPTION
In this case, we just need to override the `offsetSet` and `offsetUnset` methods to set the iterator in read-only mode.
