### PR TITLE
phpcbf fix

### DIFF
--- a/lib/Cli.php
+++ b/lib/Cli.php
@@ -303,7 +303,7 @@ class Cli {
         $this->log($this->colorize('green', '  convert') . ' source_file [output_file] Converts a file.');
         $this->log($this->colorize('green', '  color') . ' source_file                 Colorize a file, useful for debbugging.');
         $this->log(
-<<<HELP
+        <<<HELP
 
 If source_file is set as '-', STDIN will be used.
 If output_file is omitted, STDOUT will be used.


### PR DESCRIPTION
Yet another automatic fix from php-codesniffer 2.0.0~rc4, tested fine with 1.5.5 this time.
