### PR TITLE
Fix send message to all users if user is sharee with write access

### DIFF
--- a/tests/VObject/ITip/BrokerAttendeeReplyTest.php
+++ b/tests/VObject/ITip/BrokerAttendeeReplyTest.php
@@ -68,7 +68,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -218,7 +218,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -361,7 +361,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -396,7 +396,7 @@ ICS;
 
 
         $expected = [];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -458,7 +458,7 @@ ICS
             ]
 
         ];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -492,7 +492,7 @@ END:VCALENDAR
 ICS;
 
         $expected = [];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -566,7 +566,7 @@ ICS
 
             ],
         ];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -638,7 +638,7 @@ ICS
 
             ],
         ];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected,  'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -710,7 +710,7 @@ ICS
 
             ],
         ];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -775,7 +775,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -814,7 +814,7 @@ ICS;
 
         $expected = [];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -870,7 +870,7 @@ ICS;
 
         $expected = [];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -906,7 +906,7 @@ ICS;
         $version = \Sabre\VObject\Version::VERSION;
 
         $expected = [];
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -971,7 +971,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -1048,7 +1048,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -1140,7 +1140,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected);
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 }

--- a/tests/VObject/ITip/BrokerDeleteEventTest.php
+++ b/tests/VObject/ITip/BrokerDeleteEventTest.php
@@ -86,7 +86,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -172,7 +172,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -229,7 +229,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
 
     }
@@ -287,7 +287,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
 
     }
@@ -315,14 +315,14 @@ ICS;
 
         $expected = [];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
 
     }
 
     function testNoCalendar() {
 
-        $this->parse(null, null, [], 'mailto:one@example.org');
+        $this->parse(null, null, [], 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -337,7 +337,7 @@ SEQUENCE:1
 END:VTODO
 END:VCALENDAR
 ICS;
-        $this->parse($oldMessage, null, [], 'mailto:one@example.org');
+        $this->parse($oldMessage, null, [], 'mailto:one@example.org', ['mailto:strunk@example.org']);
 
     }
 

--- a/tests/VObject/ITip/BrokerNewEventTest.php
+++ b/tests/VObject/ITip/BrokerNewEventTest.php
@@ -79,7 +79,7 @@ ICS;
             ],
         ];
 
-        $this->parse(null, $message, $expected, 'mailto:strunk@example.org');
+        $this->parse(null, $message, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -104,7 +104,7 @@ END:VEVENT
 END:VCALENDAR
 ICS;
 
-        $this->parse(null, $message, [], 'mailto:strunk@example.org');
+        $this->parse(null, $message, [], 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
     /**
@@ -128,7 +128,7 @@ END:VEVENT
 END:VCALENDAR
 ICS;
 
-        $this->parse(null, $message, [], 'mailto:strunk@example.org');
+        $this->parse(null, $message, [], 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -256,7 +256,7 @@ ICS
             ],
         ];
 
-        $this->parse(null, $message, $expected, 'mailto:strunk@example.org');
+        $this->parse(null, $message, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -384,7 +384,7 @@ ICS
             ],
         ];
 
-        $this->parse(null, $message, $expected, 'mailto:strunk@example.org');
+        $this->parse(null, $message, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -405,7 +405,7 @@ ICS;
 
         $version = \Sabre\VObject\Version::VERSION;
 
-        $this->parse(null, $message, [], 'mailto:strunk@example.org');
+        $this->parse(null, $message, [], 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -439,7 +439,7 @@ END:VCALENDAR
 ICS;
 
         $version = \Sabre\VObject\Version::VERSION;
-        $this->parse(null, $message, [], 'mailto:strunk@example.org');
+        $this->parse(null, $message, [], 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -473,7 +473,7 @@ END:VCALENDAR
 ICS;
 
         $version = \Sabre\VObject\Version::VERSION;
-        $this->parse(null, $message, [], 'mailto:strunk@example.org');
+        $this->parse(null, $message, [], 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
     function testNoOrganizerHasAttendee() {

--- a/tests/VObject/ITip/BrokerShareesTest.php
+++ b/tests/VObject/ITip/BrokerShareesTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Sabre\VObject\ITip;
+
+class BrokerShareesTest extends BrokerTester {
+
+    function testShareeSendMessage() {
+
+        $oldMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:1
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=One:mailto:one@example.org
+ATTENDEE;CN=Two:mailto:two@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+
+        $newMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:2
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=Two:mailto:two@example.org
+ATTENDEE;CN=Three:mailto:three@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $version = \Sabre\VObject\Version::VERSION;
+
+        $expected = [
+            [
+                'uid'               => 'foobar',
+                'method'            => 'REQUEST',
+                'component'         => 'VEVENT',
+                'sender'            => 'mailto:strunk@example.org',
+                'senderName'        => 'Strunk',
+                'recipient'         => 'mailto:strunk@example.org',
+                'recipientName'     => 'Strunk',
+                'significantChange' => false,
+                'message'           => <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject $version//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:2
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=Two;PARTSTAT=NEEDS-ACTION:mailto:two@example.org
+ATTENDEE;CN=Three;PARTSTAT=NEEDS-ACTION:mailto:three@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS
+
+            ],
+            [
+                'uid'               => 'foobar',
+                'method'            => 'CANCEL',
+                'component'         => 'VEVENT',
+                'sender'            => 'mailto:strunk@example.org',
+                'senderName'        => 'Strunk',
+                'recipient'         => 'mailto:one@example.org',
+                'recipientName'     => 'One',
+                'significantChange' => true,
+                'message'           => <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject $version//EN
+CALSCALE:GREGORIAN
+METHOD:CANCEL
+BEGIN:VEVENT
+UID:foobar
+DTSTAMP:**ANY**
+SEQUENCE:2
+SUMMARY:foo
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=One:mailto:one@example.org
+END:VEVENT
+END:VCALENDAR
+ICS
+
+            ],
+            [
+                'uid'               => 'foobar',
+                'method'            => 'REQUEST',
+                'component'         => 'VEVENT',
+                'sender'            => 'mailto:strunk@example.org',
+                'senderName'        => 'Strunk',
+                'recipient'         => 'mailto:two@example.org',
+                'recipientName'     => 'Two',
+                'significantChange' => false,
+                'message'           => <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject $version//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:2
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=Two;PARTSTAT=NEEDS-ACTION:mailto:two@example.org
+ATTENDEE;CN=Three;PARTSTAT=NEEDS-ACTION:mailto:three@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS
+
+            ],
+            [
+                'uid'               => 'foobar',
+                'method'            => 'REQUEST',
+                'component'         => 'VEVENT',
+                'sender'            => 'mailto:strunk@example.org',
+                'senderName'        => 'Strunk',
+                'recipient'         => 'mailto:three@example.org',
+                'recipientName'     => 'Three',
+                'significantChange' => true,
+                'message'           => <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject $version//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:2
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=Two;PARTSTAT=NEEDS-ACTION:mailto:two@example.org
+ATTENDEE;CN=Three;PARTSTAT=NEEDS-ACTION:mailto:three@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS
+
+            ],
+        ];
+
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:sharee@example.org', ['mailto:strunk@example.org', 'mailto:sharee@example.org']);
+
+    }
+
+    function testShareeNotSendMessage() {
+
+        $oldMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:1
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=One:mailto:one@example.org
+ATTENDEE;CN=Two:mailto:two@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+
+        $newMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:2
+SUMMARY:foo
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=Strunk;PARTSTAT=ACCEPTED:mailto:strunk@example.org
+ATTENDEE;CN=Two:mailto:two@example.org
+ATTENDEE;CN=Three:mailto:three@example.org
+DTSTART:20140716T120000Z
+DTEND:20140716T130000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $version = \Sabre\VObject\Version::VERSION;
+
+        $expected = [];
+
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:notsharee@example.org', ['mailto:strunk@example.org', 'mailto:sharee2@example.org']);
+
+    }
+}

--- a/tests/VObject/ITip/BrokerTester.php
+++ b/tests/VObject/ITip/BrokerTester.php
@@ -15,10 +15,10 @@ abstract class BrokerTester extends \PHPUnit_Framework_TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 
-    function parse($oldMessage, $newMessage, $expected = [], $currentUser = 'mailto:one@example.org') {
+    function parse($oldMessage, $newMessage, $expected = [], $currentUser = 'mailto:one@example.org', $usersWithWriteAccessAddresses = []) {
 
         $broker = new Broker();
-        $result = $broker->parseEvent($newMessage, $currentUser, $oldMessage);
+        $result = $broker->parseEvent($newMessage, $currentUser, $usersWithWriteAccessAddresses, $oldMessage);
 
         $this->assertEquals(count($expected), count($result));
 

--- a/tests/VObject/ITip/BrokerUpdateEventTest.php
+++ b/tests/VObject/ITip/BrokerUpdateEventTest.php
@@ -135,7 +135,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -200,7 +200,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -262,7 +262,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -296,7 +296,7 @@ ICS;
         $version = \Sabre\VObject\Version::VERSION;
 
         $expected = [];
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -367,7 +367,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -507,7 +507,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -578,7 +578,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -649,7 +649,7 @@ ICS
 
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -749,7 +749,7 @@ ICS
             ],
         ];
 
-        $result = $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $result = $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 
@@ -840,7 +840,7 @@ ICS
             ],
         ];
 
-        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org');
+        $this->parse($oldMessage, $newMessage, $expected, 'mailto:strunk@example.org', ['mailto:strunk@example.org']);
 
     }
 }

--- a/tests/VObject/ITip/EvolutionTest.php
+++ b/tests/VObject/ITip/EvolutionTest.php
@@ -1734,7 +1734,7 @@ ICS;
                 'message'       => $expectedICS,
             ]
         ];
-        $this->parse(null, $ics, $expected, 'mailto:martin@fruux.com');
+        $this->parse(null, $ics, $expected, 'mailto:martin@fruux.com', ['mailto:martin@fruux.com']);
 
     }
 
@@ -2644,7 +2644,7 @@ END:VEVENT
 END:VCALENDAR
 ICS;
 
-        $this->parse($old, $new, [], 'mailto:a1@example.org');
+        $this->parse($old, $new, [], 'mailto:a1@example.org', ['mailto:o@example.org']);
 
 
     }


### PR DESCRIPTION
Add argument to parseEvent function in broker: all users with write access on a calendar. This allows to notify the attendees added by someone else that the organizer of an event. 