### PR TITLE
Improve significant change detection in RRULE to limit false positives

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -891,10 +891,10 @@ class Broker {
                 sort($exdate);
             }
             if (isset($vevent->RRULE)) {
-                foreach ($vevent->select('RRULE') as $val) {
-                    foreach($val->getParts() as $key => $val) {
+                foreach ($vevent->select('RRULE') as $rr) {
+                    foreach ($rr->getParts() as $key => $val) {
                         // ignore default values (https://github.com/sabre-io/vobject/issues/126)
-                        if ($key == 'INTERVAL' && $val == 1) {
+                        if ($key === 'INTERVAL' && $val == 1) {
                             continue;
                         }
                         $rrule[] = "$key=$val";

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -849,6 +849,7 @@ class Broker {
         $exdate = [];
 
         foreach ($calendar->VEVENT as $vevent) {
+            $rrule = [];
 
             if (is_null($uid)) {
                 $uid = $vevent->UID->getValue();
@@ -888,6 +889,18 @@ class Broker {
                     $exdate = array_merge($exdate, $val->getParts());
                 }
                 sort($exdate);
+            }
+            if (isset($vevent->RRULE)) {
+                foreach ($vevent->select('RRULE') as $val) {
+                    foreach($val->getParts() as $key => $val) {
+                        // ignore default values (https://github.com/sabre-io/vobject/issues/126)
+                        if ($key == 'INTERVAL' && $val == 1) {
+                            continue;
+                        }
+                        $rrule[] = "$key=$val";
+                    }
+                }
+                sort($rrule);
             }
             if (isset($vevent->STATUS)) {
                 $status = strtoupper($vevent->STATUS->getValue());
@@ -953,19 +966,16 @@ class Broker {
                     $significantChangeHash .= $prop . ':';
 
                     if ($prop === 'EXDATE') {
-
                         $significantChangeHash .= implode(',', $exdate) . ';';
-
+                    } elseif ($prop === 'RRULE') {
+                        $significantChangeHash .= implode(',', $rrule) . ';';
                     } else {
-
                         foreach ($propertyValues as $val) {
                             $significantChangeHash .= $val->getValue() . ';';
                         }
-
                     }
                 }
             }
-
         }
         $significantChangeHash = md5($significantChangeHash);
 

--- a/tests/VObject/ITip/BrokerSignificantChangesTest.php
+++ b/tests/VObject/ITip/BrokerSignificantChangesTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Sabre\VObject\ITip;
+
+class SignificantChangesTest extends BrokerTester {
+
+    /**
+     * Check significant changes detection (no change)
+     */
+    function testSignificantChangesNoChange() {
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Ximian//NONSGML Evolution Calendar//EN
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20140813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $new = $old;
+        $expected = [ [ 'significantChange' => false, ] ];
+
+        $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
+    }
+
+    /**
+     * Check significant changes detection (no change)
+     */
+    function testSignificantChangesRRuleNoChange() {
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Ximian//NONSGML Evolution Calendar//EN
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20140813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $new = str_replace('FREQ=WEEKLY', 'FREQ=WEEKLY;INTERVAL=1', $old);
+        $expected = [ [ 'significantChange' => false, ] ];
+
+        $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
+    }
+
+
+    /**
+     * Check significant changes detection (no change)
+     */
+    function testSignificantChangesRRuleOrderNoChange() {
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Ximian//NONSGML Evolution Calendar//EN
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20140813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY;BYDAY=MO
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $new = str_replace('FREQ=WEEKLY;BYDAY=MO', 'BYDAY=MO;FREQ=WEEKLY', $old);
+        $expected = [ [ 'significantChange' => false, ] ];
+
+        $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
+    }
+
+}

--- a/tests/VObject/ITip/BrokerSignificantChangesTest.php
+++ b/tests/VObject/ITip/BrokerSignificantChangesTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\VObject\ITip;
 
-class SignificantChangesTest extends BrokerTester {
+class BrokerSignificantChangesTest extends BrokerTester {
 
     /**
      * Check significant changes detection (no change)
@@ -33,7 +33,7 @@ END:VCALENDAR
 ICS;
 
         $new = $old;
-        $expected = [ [ 'significantChange' => false, ] ];
+        $expected = [['significantChange' => false, ]];
 
         $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
     }
@@ -67,7 +67,7 @@ END:VCALENDAR
 ICS;
 
         $new = str_replace('FREQ=WEEKLY', 'FREQ=WEEKLY;INTERVAL=1', $old);
-        $expected = [ [ 'significantChange' => false, ] ];
+        $expected = [['significantChange' => false, ]];
 
         $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
     }
@@ -102,7 +102,7 @@ END:VCALENDAR
 ICS;
 
         $new = str_replace('FREQ=WEEKLY;BYDAY=MO', 'BYDAY=MO;FREQ=WEEKLY', $old);
-        $expected = [ [ 'significantChange' => false, ] ];
+        $expected = [['significantChange' => false, ]];
 
         $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
     }


### PR DESCRIPTION
Fixes part of #126.

Ignores insignificant changes in RRULE. E.g. ignores INTERVAL=1 and order of items.