### PR TITLE
Canada/East-Saskatchewan removed in 2017.3

### DIFF
--- a/lib/timezonedata/php-bc.php
+++ b/lib/timezonedata/php-bc.php
@@ -68,7 +68,6 @@ return [
     'Brazil/West',
     'Canada/Atlantic',
     'Canada/Central',
-    'Canada/East-Saskatchewan',
     'Canada/Eastern',
     'Canada/Mountain',
     'Canada/Newfoundland',


### PR DESCRIPTION
Discovered in Fedora QA since tzdata 2017c
https://apps.fedoraproject.org/koschei/package/php-sabre-vobject4?collection=f28

```
There was 1 error:
1) Sabre\VObject\TimeZoneUtilTest::testTimeZoneBCIdentifiers with data set #52 ('Canada/East-Saskatchewan')
Exception: DateTimeZone::__construct(): Unknown or bad timezone (Canada/East-Saskatchewan)
/builddir/build/BUILD/vobject-df9916813d1d83e4f761c4cba13361ee74196fac/tests/VObject/TimeZoneUtilTest.php:181

```
Also see http://git.php.net/?p=php-src.git;a=commitdiff;h=b2dfcb30eb7de65fbb0e86d5fc79419c8851c005