### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "sabre/xml"    : ">=1.5 <3.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "> 4.8, <6.0.0",
+        "phpunit/phpunit" : "> 4.8.35, <6.0.0",
         "sabre/cs"        : "^1.0.0"
 
     },

--- a/tests/VObject/AttachIssueTest.php
+++ b/tests/VObject/AttachIssueTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class AttachIssueTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class AttachIssueTest extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/BirthdayCalendarGeneratorTest.php
+++ b/tests/VObject/BirthdayCalendarGeneratorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class BirthdayCalendarGeneratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class BirthdayCalendarGeneratorTest extends TestCase {
 
     use PHPUnitAssertions;
 

--- a/tests/VObject/CliTest.php
+++ b/tests/VObject/CliTest.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the cli.
  *
  * Warning: these tests are very rudimentary.
  */
-class CliTest extends \PHPUnit_Framework_TestCase {
+class CliTest extends TestCase {
 
     function setUp() {
 

--- a/tests/VObject/Component/AvailableTest.php
+++ b/tests/VObject/Component/AvailableTest.php
@@ -4,13 +4,14 @@ namespace Sabre\VObject\Component;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 /**
  * We use `RFCxxx` has a placeholder for the
  * https://tools.ietf.org/html/draft-daboo-calendar-availability-05 name.
  */
-class AvailableTest extends \PHPUnit_Framework_TestCase {
+class AvailableTest extends TestCase {
 
     function testAvailableComponent() {
 

--- a/tests/VObject/Component/VAlarmTest.php
+++ b/tests/VObject/Component/VAlarmTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\Component;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class VAlarmTest extends \PHPUnit_Framework_TestCase {
+class VAlarmTest extends TestCase {
 
     /**
      * @dataProvider timeRangeTestData

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Component;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 use Sabre\VObject\Reader;
 
@@ -11,7 +12,7 @@ use Sabre\VObject\Reader;
  * We use `RFCxxx` has a placeholder for the
  * https://tools.ietf.org/html/draft-daboo-calendar-availability-05 name.
  */
-class VAvailabilityTest extends \PHPUnit_Framework_TestCase {
+class VAvailabilityTest extends TestCase {
 
     function testVAvailabilityComponent() {
 

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\Component;
 
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class VCalendarTest extends \PHPUnit_Framework_TestCase {
+class VCalendarTest extends TestCase {
 
     use VObject\PHPUnitAssertions;
 

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class VCardTest extends \PHPUnit_Framework_TestCase {
+class VCardTest extends TestCase {
 
     /**
      * @dataProvider validateData

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject\Component;
 
-class VEventTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class VEventTest extends TestCase {
 
     /**
      * @dataProvider timeRangeTestData

--- a/tests/VObject/Component/VFreeBusyTest.php
+++ b/tests/VObject/Component/VFreeBusyTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 use Sabre\VObject\Reader;
 
-class VFreeBusyTest extends \PHPUnit_Framework_TestCase {
+class VFreeBusyTest extends TestCase {
 
     function testIsFree() {
 

--- a/tests/VObject/Component/VJournalTest.php
+++ b/tests/VObject/Component/VJournalTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component;
 use Sabre\VObject\Reader;
 
-class VJournalTest extends \PHPUnit_Framework_TestCase {
+class VJournalTest extends TestCase {
 
     /**
      * @dataProvider timeRangeTestData

--- a/tests/VObject/Component/VTimeZoneTest.php
+++ b/tests/VObject/Component/VTimeZoneTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class VTimeZoneTest extends \PHPUnit_Framework_TestCase {
+class VTimeZoneTest extends TestCase {
 
     function testValidate() {
 

--- a/tests/VObject/Component/VTodoTest.php
+++ b/tests/VObject/Component/VTodoTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component;
 use Sabre\VObject\Reader;
 
-class VTodoTest extends \PHPUnit_Framework_TestCase {
+class VTodoTest extends TestCase {
 
     /**
      * @dataProvider timeRangeTestData

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VCard;
 
-class ComponentTest extends \PHPUnit_Framework_TestCase {
+class ComponentTest extends TestCase {
 
     function testIterate() {
 

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -5,8 +5,9 @@ namespace Sabre\VObject;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
+class DateTimeParserTest extends TestCase {
 
     function testParseICalendarDuration() {
 

--- a/tests/VObject/DocumentTest.php
+++ b/tests/VObject/DocumentTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class DocumentTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class DocumentTest extends TestCase {
 
     function testGetDocumentType() {
 

--- a/tests/VObject/ElementListTest.php
+++ b/tests/VObject/ElementListTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class ElementListTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ElementListTest extends TestCase {
 
     function testIterate() {
 

--- a/tests/VObject/EmClientTest.php
+++ b/tests/VObject/EmClientTest.php
@@ -3,8 +3,9 @@
 namespace Sabre\VObject;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
 
-class EmClientTest extends \PHPUnit_Framework_TestCase {
+class EmClientTest extends TestCase {
 
     function testParseTz() {
 

--- a/tests/VObject/EmptyParameterTest.php
+++ b/tests/VObject/EmptyParameterTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class EmptyParameterTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class EmptyParameterTest extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/EmptyValueIssueTest.php
+++ b/tests/VObject/EmptyValueIssueTest.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * This test is written for Issue 68:
  *
  * https://github.com/fruux/sabre-vobject/issues/68
  */
-class EmptyValueIssueTest extends \PHPUnit_Framework_TestCase {
+class EmptyValueIssueTest extends TestCase {
 
     function testDecodeValue() {
 

--- a/tests/VObject/FreeBusyDataTest.php
+++ b/tests/VObject/FreeBusyDataTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class FreeBusyDataTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class FreeBusyDataTest extends TestCase {
 
     function testGetData() {
 

--- a/tests/VObject/FreeBusyGeneratorTest.php
+++ b/tests/VObject/FreeBusyGeneratorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class FreeBusyGeneratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class FreeBusyGeneratorTest extends TestCase {
 
     use PHPUnitAssertions;
 

--- a/tests/VObject/GoogleColonEscapingTest.php
+++ b/tests/VObject/GoogleColonEscapingTest.php
@@ -2,13 +2,15 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Google produces vcards with a weird escaping of urls.
  *
  * VObject will provide a workaround for this, so end-user still get expected
  * values.
  */
-class GoogleColonEscapingTest extends \PHPUnit_Framework_TestCase {
+class GoogleColonEscapingTest extends TestCase {
 
     function testDecode() {
 

--- a/tests/VObject/ICalendar/AttachParseTest.php
+++ b/tests/VObject/ICalendar/AttachParseTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\ICalendar;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class AttachParseTest extends \PHPUnit_Framework_TestCase {
+class AttachParseTest extends TestCase {
 
     /**
      * See issue #128 for more info.

--- a/tests/VObject/ITip/BrokerTester.php
+++ b/tests/VObject/ITip/BrokerTester.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\ITip;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 /**
@@ -11,7 +12,7 @@ use Sabre\VObject\Reader;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-abstract class BrokerTester extends \PHPUnit_Framework_TestCase {
+abstract class BrokerTester extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 

--- a/tests/VObject/ITip/BrokerTimezoneInParseEventInfoWithoutMasterTest.php
+++ b/tests/VObject/ITip/BrokerTimezoneInParseEventInfoWithoutMasterTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\ITip;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class BrokerTimezoneInParseEventInfoWithoutMasterTest extends \PHPUnit_Framework_TestCase {
+class BrokerTimezoneInParseEventInfoWithoutMasterTest extends TestCase {
 
     function testTimezoneInParseEventInfoWithoutMaster()
     {

--- a/tests/VObject/ITip/MessageTest.php
+++ b/tests/VObject/ITip/MessageTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject\ITip;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MessageTest extends TestCase {
 
     function testNoScheduleStatus() {
 

--- a/tests/VObject/Issue153Test.php
+++ b/tests/VObject/Issue153Test.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class Issue153Test extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Issue153Test extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/Issue259Test.php
+++ b/tests/VObject/Issue259Test.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class Issue259Test extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Issue259Test extends TestCase {
 
     function testParsingJcalWithUntil() {
         $jcalWithUntil = '["vcalendar",[],[["vevent",[["uid",{},"text","dd1f7d29"],["organizer",{"cn":"robert"},"cal-address","mailto:robert@robert.com"],["dtstart",{"tzid":"Europe/Berlin"},"date-time","2015-10-21T12:00:00"],["dtend",{"tzid":"Europe/Berlin"},"date-time","2015-10-21T13:00:00"],["transp",{},"text","OPAQUE"],["rrule",{},"recur",{"freq":"MONTHLY","until":"2016-01-01T22:00:00Z"}]],[]]]]';

--- a/tests/VObject/Issue36WorkAroundTest.php
+++ b/tests/VObject/Issue36WorkAroundTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class Issue36WorkAroundTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Issue36WorkAroundTest extends TestCase {
 
     function testWorkaround() {
 

--- a/tests/VObject/Issue40Test.php
+++ b/tests/VObject/Issue40Test.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * This test is created to handle the issues brought forward by issue 40.
  *
  * https://github.com/fruux/sabre-vobject/issues/40
  */
-class Issue40Test extends \PHPUnit_Framework_TestCase {
+class Issue40Test extends TestCase {
 
     function testEncode() {
 

--- a/tests/VObject/Issue64Test.php
+++ b/tests/VObject/Issue64Test.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class Issue64Test extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Issue64Test extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/Issue96Test.php
+++ b/tests/VObject/Issue96Test.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class Issue96Test extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Issue96Test extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/IssueUndefinedIndexTest.php
+++ b/tests/VObject/IssueUndefinedIndexTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class IssueUndefinedIndexTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class IssueUndefinedIndexTest extends TestCase {
 
     /**
      * @expectedException \Sabre\VObject\ParseException

--- a/tests/VObject/JCalTest.php
+++ b/tests/VObject/JCalTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class JCalTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class JCalTest extends TestCase {
 
     function testToJCal() {
 

--- a/tests/VObject/JCardTest.php
+++ b/tests/VObject/JCardTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class JCardTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class JCardTest extends TestCase {
 
     function testToJCard() {
 

--- a/tests/VObject/LineFoldingIssueTest.php
+++ b/tests/VObject/LineFoldingIssueTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class LineFoldingIssueTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class LineFoldingIssueTest extends TestCase {
 
     function testRead() {
 

--- a/tests/VObject/ParameterTest.php
+++ b/tests/VObject/ParameterTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class ParameterTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ParameterTest extends TestCase {
 
     function testSetup() {
 

--- a/tests/VObject/Parser/JsonTest.php
+++ b/tests/VObject/Parser/JsonTest.php
@@ -2,10 +2,10 @@
 
 namespace Sabre\VObject\Parser;
 
-use
-    Sabre\VObject;
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject;
 
-class JsonTest extends \PHPUnit_Framework_TestCase {
+class JsonTest extends TestCase {
 
     function testRoundTripJCard() {
 

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -2,11 +2,13 @@
 
 namespace Sabre\VObject\Parser;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Note that most MimeDir related tests can actually be found in the ReaderTest
  * class one level up.
  */
-class MimeDirTest extends \PHPUnit_Framework_TestCase {
+class MimeDirTest extends TestCase {
 
     /**
      * @expectedException \Sabre\VObject\ParseException

--- a/tests/VObject/Parser/QuotedPrintableTest.php
+++ b/tests/VObject/Parser/QuotedPrintableTest.php
@@ -2,10 +2,10 @@
 
 namespace Sabre\VObject\Parser;
 
-use
-    Sabre\VObject\Reader;
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Reader;
 
-class QuotedPrintableTest extends \PHPUnit_Framework_TestCase {
+class QuotedPrintableTest extends TestCase {
 
     function testReadQuotedPrintableSimple() {
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class XmlTest extends \PHPUnit_Framework_TestCase {
+class XmlTest extends TestCase {
 
     use VObject\PHPUnitAssertions;
 

--- a/tests/VObject/Property/BinaryTest.php
+++ b/tests/VObject/Property/BinaryTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class BinaryTest extends \PHPUnit_Framework_TestCase {
+class BinaryTest extends TestCase {
 
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/VObject/Property/BooleanTest.php
+++ b/tests/VObject/Property/BooleanTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class BooleanTest extends \PHPUnit_Framework_TestCase {
+class BooleanTest extends TestCase {
 
     function testMimeDir() {
 

--- a/tests/VObject/Property/CompoundTest.php
+++ b/tests/VObject/Property/CompoundTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCard;
 
-class CompoundTest extends \PHPUnit_Framework_TestCase {
+class CompoundTest extends TestCase {
 
     function testSetParts() {
 

--- a/tests/VObject/Property/FloatTest.php
+++ b/tests/VObject/Property/FloatTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class FloatTest extends \PHPUnit_Framework_TestCase {
+class FloatTest extends TestCase {
 
     function testMimeDir() {
 

--- a/tests/VObject/Property/ICalendar/CalAddressTest.php
+++ b/tests/VObject/Property/ICalendar/CalAddressTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
-class CalAddressTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class CalAddressTest extends TestCase {
 
     /**
      * @dataProvider values

--- a/tests/VObject/Property/ICalendar/DateTimeTest.php
+++ b/tests/VObject/Property/ICalendar/DateTimeTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 
-class DateTimeTest extends \PHPUnit_Framework_TestCase {
+class DateTimeTest extends TestCase {
 
     protected $vcal;
 

--- a/tests/VObject/Property/ICalendar/DurationTest.php
+++ b/tests/VObject/Property/ICalendar/DurationTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VEvent;
 
-class DurationTest extends \PHPUnit_Framework_TestCase {
+class DurationTest extends TestCase {
 
     function testGetDateInterval() {
 

--- a/tests/VObject/Property/ICalendar/RecurTest.php
+++ b/tests/VObject/Property/ICalendar/RecurTest.php
@@ -2,11 +2,12 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Node;
 use Sabre\VObject\Reader;
 
-class RecurTest extends \PHPUnit_Framework_TestCase {
+class RecurTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 

--- a/tests/VObject/Property/TextTest.php
+++ b/tests/VObject/Property/TextTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCard;
 
-class TextTest extends \PHPUnit_Framework_TestCase {
+class TextTest extends TestCase {
 
     function assertVCard21Serialization($propValue, $expected) {
 

--- a/tests/VObject/Property/UriTest.php
+++ b/tests/VObject/Property/UriTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class UriTest extends \PHPUnit_Framework_TestCase {
+class UriTest extends TestCase {
 
     function testAlwaysEncodeUriVCalendar() {
 

--- a/tests/VObject/Property/VCard/DateAndOrTimeTest.php
+++ b/tests/VObject/Property/VCard/DateAndOrTimeTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Property\VCard;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 use Sabre\VObject\Reader;
 
-class DateAndOrTimeTest extends \PHPUnit_Framework_TestCase {
+class DateAndOrTimeTest extends TestCase {
 
     /**
      * @dataProvider dates

--- a/tests/VObject/Property/VCard/LanguageTagTest.php
+++ b/tests/VObject/Property/VCard/LanguageTagTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Property\VCard;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class LanguageTagTest extends \PHPUnit_Framework_TestCase {
+class LanguageTagTest extends TestCase {
 
     function testMimeDir() {
 

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VCard;
 
-class PropertyTest extends \PHPUnit_Framework_TestCase {
+class PropertyTest extends TestCase {
 
     function testToString() {
 

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class ReaderTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ReaderTest extends TestCase {
 
     function testReadComponent() {
 

--- a/tests/VObject/Recur/EventIterator/ByMonthInDailyTest.php
+++ b/tests/VObject/Recur/EventIterator/ByMonthInDailyTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\Recur;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class ByMonthInDailyTest extends \PHPUnit_Framework_TestCase {
+class ByMonthInDailyTest extends TestCase {
 
     /**
      * This tests the expansion of dates with DAILY frequency in RRULE with BYMONTH restrictions

--- a/tests/VObject/Recur/EventIterator/BySetPosHangTest.php
+++ b/tests/VObject/Recur/EventIterator/BySetPosHangTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\Recur;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class BySetPosHangTest extends \PHPUnit_Framework_TestCase {
+class BySetPosHangTest extends TestCase {
 
     /**
      * Using this iCalendar object, including BYSETPOS=-2 causes the iterator

--- a/tests/VObject/Recur/EventIterator/ExpandFloatingTimesTest.php
+++ b/tests/VObject/Recur/EventIterator/ExpandFloatingTimesTest.php
@@ -4,9 +4,10 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class ExpandFloatingTimesTest extends \PHPUnit_Framework_TestCase {
+class ExpandFloatingTimesTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 

--- a/tests/VObject/Recur/EventIterator/FifthTuesdayProblemTest.php
+++ b/tests/VObject/Recur/EventIterator/FifthTuesdayProblemTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Recur\EventIterator;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur;
 
-class FifthTuesdayProblemTest extends \PHPUnit_Framework_TestCase {
+class FifthTuesdayProblemTest extends TestCase {
 
     /**
      * A pretty slow test. Had to be marked as 'medium' for phpunit to not die

--- a/tests/VObject/Recur/EventIterator/HandleRDateExpandTest.php
+++ b/tests/VObject/Recur/EventIterator/HandleRDateExpandTest.php
@@ -5,12 +5,13 @@ namespace Sabre\VObject\Recur\EventIterator;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 /**
  * This is a unittest for Issue #53.
  */
-class HandleRDateExpandTest extends \PHPUnit_Framework_TestCase {
+class HandleRDateExpandTest extends TestCase {
 
     function testExpand() {
 
@@ -54,7 +55,7 @@ ICS;
 
         $result = array_map(function($ev) {return $ev->DTSTART->getDateTime();}, $result);
         $this->assertEquals($expected, $result);
-    
+
     }
 
 }

--- a/tests/VObject/Recur/EventIterator/IncorrectExpandTest.php
+++ b/tests/VObject/Recur/EventIterator/IncorrectExpandTest.php
@@ -3,12 +3,13 @@
 namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 /**
  * This is a unittest for Issue #53.
  */
-class IncorrectExpandTest extends \PHPUnit_Framework_TestCase {
+class IncorrectExpandTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 
@@ -56,7 +57,7 @@ END:VCALENDAR
 
 ICS;
         $this->assertVObjectEqualsVObject($output, $vcal);
-    
+
     }
 
 }

--- a/tests/VObject/Recur/EventIterator/InfiniteLoopProblemTest.php
+++ b/tests/VObject/Recur/EventIterator/InfiniteLoopProblemTest.php
@@ -4,10 +4,11 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Recur;
 
-class InfiniteLoopProblemTest extends \PHPUnit_Framework_TestCase {
+class InfiniteLoopProblemTest extends TestCase {
 
     function setUp() {
 

--- a/tests/VObject/Recur/EventIterator/Issue26Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue26Test.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\VObject\Recur\EventIterator;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
 
-class Issue26Test extends \PHPUnit_Framework_TestCase {
+class Issue26Test extends TestCase {
 
     /**
      * @expectedException \Sabre\VObject\InvalidDataException

--- a/tests/VObject/Recur/EventIterator/Issue48Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue48Test.php
@@ -4,8 +4,9 @@ namespace Sabre\VObject;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class Issue48Test extends \PHPUnit_Framework_TestCase {
+class Issue48Test extends TestCase {
 
     function testExpand() {
 

--- a/tests/VObject/Recur/EventIterator/Issue50Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue50Test.php
@@ -4,8 +4,9 @@ namespace Sabre\VObject;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class Issue50Test extends \PHPUnit_Framework_TestCase {
+class Issue50Test extends TestCase {
 
     function testExpand() {
 

--- a/tests/VObject/Recur/EventIterator/MainTest.php
+++ b/tests/VObject/Recur/EventIterator/MainTest.php
@@ -4,10 +4,11 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Recur\EventIterator;
 
-class MainTest extends \PHPUnit_Framework_TestCase {
+class MainTest extends TestCase {
 
     function testValues() {
 

--- a/tests/VObject/Recur/EventIterator/MaxInstancesTest.php
+++ b/tests/VObject/Recur/EventIterator/MaxInstancesTest.php
@@ -3,10 +3,11 @@
 namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Settings;
 
-class MaxInstancesTest extends \PHPUnit_Framework_TestCase {
+class MaxInstancesTest extends TestCase {
 
     /**
      * @expectedException \Sabre\VObject\Recur\MaxInstancesExceededException

--- a/tests/VObject/Recur/EventIterator/MissingOverriddenTest.php
+++ b/tests/VObject/Recur/EventIterator/MissingOverriddenTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class MissingOverriddenTest extends \PHPUnit_Framework_TestCase {
+class MissingOverriddenTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 
@@ -56,7 +57,7 @@ END:VEVENT
 END:VCALENDAR
 ICS;
         $this->assertVObjectEqualsVObject($output, $vcal);
-    
+
     }
 
 }

--- a/tests/VObject/Recur/EventIterator/NoInstancesTest.php
+++ b/tests/VObject/Recur/EventIterator/NoInstancesTest.php
@@ -2,10 +2,10 @@
 
 namespace Sabre\VObject\Recur;
 
-use
-    Sabre\VObject\Reader;
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Reader;
 
-class NoInstancesTest extends \PHPUnit_Framework_TestCase {
+class NoInstancesTest extends TestCase {
 
     /**
      * @expectedException \Sabre\VObject\Recur\NoInstancesException

--- a/tests/VObject/Recur/EventIterator/OverrideFirstEventTest.php
+++ b/tests/VObject/Recur/EventIterator/OverrideFirstEventTest.php
@@ -3,9 +3,10 @@
 namespace Sabre\VObject\RecurrenceIterator;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
-class OverrideFirstEventTest extends \PHPUnit_Framework_TestCase {
+class OverrideFirstEventTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 

--- a/tests/VObject/Recur/EventIterator/SameDateForRecurringEventsTest.php
+++ b/tests/VObject/Recur/EventIterator/SameDateForRecurringEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Recur;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 /**
@@ -9,7 +10,7 @@ use Sabre\VObject\Reader;
  *
  * Class SameDateForRecurringEventsTest
  */
-class SameDateForRecurringEventsTest extends \PHPUnit_Framework_TestCase
+class SameDateForRecurringEventsTest extends TestCase
 {
 
     /**

--- a/tests/VObject/Recur/RDateIteratorTest.php
+++ b/tests/VObject/Recur/RDateIteratorTest.php
@@ -4,8 +4,9 @@ namespace Sabre\VObject\Recur;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class RDateIteratorTest extends \PHPUnit_Framework_TestCase {
+class RDateIteratorTest extends TestCase {
 
     function testSimple() {
 

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -4,8 +4,9 @@ namespace Sabre\VObject\Recur;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class RRuleIteratorTest extends \PHPUnit_Framework_TestCase {
+class RRuleIteratorTest extends TestCase {
 
     function testHourly() {
 

--- a/tests/VObject/SlashRTest.php
+++ b/tests/VObject/SlashRTest.php
@@ -2,11 +2,13 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * This issue was pointed out in Issue 55. \r should be stripped completely
  * when encoding property values.
  */
-class SlashRTest extends \PHPUnit_Framework_TestCase {
+class SlashRTest extends TestCase {
 
     function testEncode() {
 

--- a/tests/VObject/Splitter/ICalendarTest.php
+++ b/tests/VObject/Splitter/ICalendarTest.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\VObject\Splitter;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
-class ICalendarTest extends \PHPUnit_Framework_TestCase {
+class ICalendarTest extends TestCase {
 
     protected $version;
 

--- a/tests/VObject/Splitter/VCardTest.php
+++ b/tests/VObject/Splitter/VCardTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject\Splitter;
 
-class VCardTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class VCardTest extends TestCase {
 
     function createStream($data) {
 

--- a/tests/VObject/StringUtilTest.php
+++ b/tests/VObject/StringUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class StringUtilTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class StringUtilTest extends TestCase {
 
     function testNonUTF8() {
 

--- a/tests/VObject/TimeZoneUtilTest.php
+++ b/tests/VObject/TimeZoneUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class TimeZoneUtilTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class TimeZoneUtilTest extends TestCase {
 
     function setUp() {
 

--- a/tests/VObject/UUIDUtilTest.php
+++ b/tests/VObject/UUIDUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class UUIDUtilTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class UUIDUtilTest extends TestCase {
 
     function testValidateUUID() {
 

--- a/tests/VObject/VCard21Test.php
+++ b/tests/VObject/VCard21Test.php
@@ -2,10 +2,12 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Assorted vcard 2.1 tests.
  */
-class VCard21Test extends \PHPUnit_Framework_TestCase {
+class VCard21Test extends TestCase {
 
     function testPropertyWithNoName() {
 

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class VCardConverterTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class VCardConverterTest extends TestCase {
 
     use \Sabre\VObject\PHPUnitAssertions;
 

--- a/tests/VObject/VersionTest.php
+++ b/tests/VObject/VersionTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class VersionTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class VersionTest extends TestCase {
 
     function testString() {
 

--- a/tests/VObject/WriterTest.php
+++ b/tests/VObject/WriterTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject;
 
-class WriterTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class WriterTest extends TestCase {
 
     function getComponent() {
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`> 4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.