### PR TITLE
Allow utf-8 as charset

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -466,6 +466,7 @@ class MimeDir extends Parser {
             }
             switch ($charset) {
                 case 'UTF-8' :
+                case 'utf-8' :
                     break;
                 case 'ISO-8859-1' :
                     $property['value'] = utf8_encode($property['value']);

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -142,4 +142,19 @@ VCF;
         $this->assertEquals("Euro \xE2\x82\xAC", $vcard->FN->getValue());
 
     }
+
+    function testDecodeutf8() {
+
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:2.1
+FN;CHARSET=utf-8:Hello
+END:VCARD\n
+VCF;
+
+        $mimeDir = new MimeDir();
+        $vcard = $mimeDir->parse($vcard);
+        $this->assertEquals("Hello", $vcard->FN->getValue());
+
+	}
 }


### PR DESCRIPTION
Even if not strictly valid. Outlook sometimes sets te charset to utf-8
(lowercase) on certain properties. So better just accept this.