### PR TITLE
Modify the date to check in yearly test correctly as it is immutable

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -592,11 +592,11 @@ class RRuleIterator implements Iterator {
                     // loop through all YearDay and Days to check all the combinations
                     foreach ($this->byYearDay as $byYearDay) {
                         $date = clone $this->currentDate;
-                        $date->setDate($currentYear, 1, 1);
+                        $date = $date->setDate($currentYear, 1, 1);
                         if ($byYearDay > 0) {
-                            $date->add(new \DateInterval('P' . $byYearDay . 'D'));
+                            $date = $date->add(new \DateInterval('P' . $byYearDay . 'D'));
                         } else {
-                            $date->sub(new \DateInterval('P' . abs($byYearDay) . 'D'));
+                            $date = $date->sub(new \DateInterval('P' . abs($byYearDay) . 'D'));
                         }
 
                         if ($date > $this->currentDate && in_array($date->format('N'), $dayOffsets)) {

--- a/tests/VObject/Recur/EventIterator/YearlyByYeardayTest.php
+++ b/tests/VObject/Recur/EventIterator/YearlyByYeardayTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sabre\VObject\Recur;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Reader;
+
+class YearlyByYeardayTest extends TestCase {
+
+    /**
+     * This tests the expansion of dates with DAILY frequency in RRULE with BYMONTH restrictions
+     */
+    function testExpand() {
+
+        $ics = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//iCal 4.0.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+TRANSP:OPAQUE
+DTSTART:20070102T160000Z
+DTEND:20070102T183000Z
+RRULE:FREQ=YEARLY;BYYEARDAY=1
+UID:uuid
+DTSTAMP:19700101T000000Z
+LOCATION:
+DESCRIPTION:
+STATUS:CONFIRMED
+SEQUENCE:18
+SUMMARY:Stuff
+CREATED:20071004T144642Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $vcal = Reader::read($ics);
+        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+
+        $vcal = $vcal->expand(new DateTime('2007-01-01'), new DateTime('2008-01-03'));
+
+        foreach ($vcal->VEVENT as $event) {
+            $dates[] = $event->DTSTART->getValue();
+        }
+
+        $expectedDates = [
+            "20070102T160000Z",
+            "20080102T160000Z"
+        ];
+
+        $this->assertEquals($expectedDates, $dates, 'Recursed dates are restricted by year day');
+    }
+
+}


### PR DESCRIPTION
As the current date is immutable in the RRuleIterator, the yearly date needs to be reassigned in the check, otherwise it will be always the same date and turn out in an infinite loop. 