### PR TITLE
move a single substr() call from MimeDir::readline() in the hot-path

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -315,8 +315,9 @@ class MimeDir extends Parser {
                 break;
             }
             if ($nextLine[0] === "\t" || $nextLine[0] === " ") {
-                $line .= substr($nextLine, 1);
-                $rawLine .= "\n " . substr($nextLine, 1);
+                $curLine = substr($nextLine, 1); 
+                $line .= $curLine;
+                $rawLine .= "\n " . $curLine;
             } else {
                 $this->lineBuffer = $nextLine;
                 break;


### PR DESCRIPTION
see profile

![grafik](https://user-images.githubusercontent.com/120441/38691492-4356e4e6-3e81-11e8-85e0-9e1356f1acfe.png)
