### PR TITLE
use full qualified function calls in Property/Text->serialize()

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -283,22 +283,22 @@ class MimeDir extends Parser {
      */
     protected function readLine() {
 
-        if (!is_null($this->lineBuffer)) {
+        if (!\is_null($this->lineBuffer)) {
             $rawLine = $this->lineBuffer;
             $this->lineBuffer = null;
         } else {
             do {
-                $eof = feof($this->input);
+                $eof = \feof($this->input);
 
-                $rawLine = fgets($this->input);
+                $rawLine = \fgets($this->input);
 
-                if ($eof || (feof($this->input) && $rawLine === false)) {
+                if ($eof || (\feof($this->input) && $rawLine === false)) {
                     throw new EofException('End of document reached prematurely');
                 }
                 if ($rawLine === false) {
                     throw new ParseException('Error reading from input stream');
                 }
-                $rawLine = rtrim($rawLine, "\r\n");
+                $rawLine = \rtrim($rawLine, "\r\n");
             } while ($rawLine === ''); // Skipping empty lines
             $this->lineIndex++;
         }
@@ -309,13 +309,13 @@ class MimeDir extends Parser {
         // Looking ahead for folded lines.
         while (true) {
 
-            $nextLine = rtrim(fgets($this->input), "\r\n");
+            $nextLine = \rtrim(\fgets($this->input), "\r\n");
             $this->lineIndex++;
             if (!$nextLine) {
                 break;
             }
             if ($nextLine[0] === "\t" || $nextLine[0] === " ") {
-                $curLine = substr($nextLine, 1);
+                $curLine = \substr($nextLine, 1);
                 $line .= $curLine;
                 $rawLine .= "\n " . $curLine;
             } else {

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -247,11 +247,11 @@ abstract class Property extends Node {
         $str .= ':' . $this->getRawMimeDirValue();
 
         $out = '';
-        while (($len = strlen($str)) > 0) {
+        while (($len = \strlen($str)) > 0) {
             if ($len > 75) {
-                $part = mb_strcut($str, 0, 75, 'utf-8');
+                $part = \mb_strcut($str, 0, 75, 'utf-8');
                 $out .= $part . "\r\n";
-                $str = ' ' . substr($str, strlen($part));
+                $str = ' ' . \substr($str, \strlen($part));
             } else {
                 $out .= $str . "\r\n";
                 $str = '';

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -213,16 +213,16 @@ class Text extends Property {
         $val = $this->getParts();
 
         if (isset($this->minimumPropertyValues[$this->name])) {
-            $val = array_pad($val, $this->minimumPropertyValues[$this->name], '');
+            $val = \array_pad($val, $this->minimumPropertyValues[$this->name], '');
         }
 
         // Imploding multiple parts into a single value, and splitting the
         // values with ;.
         if (count($val) > 1) {
             foreach ($val as $k => $v) {
-                $val[$k] = str_replace(';', '\;', $v);
+                $val[$k] = \str_replace(';', '\;', $v);
             }
-            $val = implode(';', $val);
+            $val = \implode(';', $val);
         } else {
             $val = $val[0];
         }
@@ -242,7 +242,7 @@ class Text extends Property {
 
         // If the resulting value contains a \n, we must encode it as
         // quoted-printable.
-        if (strpos($val, "\n") !== false) {
+        if (\strpos($val, "\n") !== false) {
 
             $str .= ';ENCODING=QUOTED-PRINTABLE:';
             $lastLine = $str;
@@ -252,15 +252,15 @@ class Text extends Property {
             // encode newlines for us. Specifically, the \r\n sequence must in
             // vcards be encoded as =0D=OA and we must insert soft-newlines
             // every 75 bytes.
-            for ($ii = 0;$ii < strlen($val);$ii++) {
-                $ord = ord($val[$ii]);
+            for ($ii = 0;$ii < \strlen($val);$ii++) {
+                $ord = \ord($val[$ii]);
                 // These characters are encoded as themselves.
                 if ($ord >= 32 && $ord <= 126) {
                     $lastLine .= $val[$ii];
                 } else {
-                    $lastLine .= '=' . strtoupper(bin2hex($val[$ii]));
+                    $lastLine .= '=' . \strtoupper(\bin2hex($val[$ii]));
                 }
-                if (strlen($lastLine) >= 75) {
+                if (\strlen($lastLine) >= 75) {
                     // Soft line break
                     $out .= $lastLine . "=\r\n ";
                     $lastLine = null;
@@ -273,11 +273,11 @@ class Text extends Property {
         } else {
             $str .= ':' . $val;
             $out = '';
-            while (($len = strlen($str)) > 0) {
+            while (($len = \strlen($str)) > 0) {
                 if ($len > 75) {
-                    $part = mb_strcut($str, 0, 75, 'utf-8');
+                    $part = \mb_strcut($str, 0, 75, 'utf-8');
                     $out .= $part . "\r\n";
-                    $str = ' ' . substr($str, strlen($part));
+                    $str = ' ' . \substr($str, \strlen($part));
                 } else {
                     $out .= $str . "\r\n";
                     $str = '';

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -218,7 +218,7 @@ class Text extends Property {
 
         // Imploding multiple parts into a single value, and splitting the
         // values with ;.
-        if (count($val) > 1) {
+        if (\count($val) > 1) {
             foreach ($val as $k => $v) {
                 $val[$k] = \str_replace(';', '\;', $v);
             }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -267,7 +267,7 @@ class Text extends Property {
                 }
 
             }
-            if (!is_null($lastLine)) $out .= $lastLine . "\r\n";
+            if (!\is_null($lastLine)) $out .= $lastLine . "\r\n";
             return $out;
 
         } else {


### PR DESCRIPTION
explcitly use full qualified function calls so PHP can generate faster opcodes and doesn't need to check the local namespace for equal named functions before using the native function.

applied the changes only in the HOT path.