### PR TITLE
use preg_replace instead of mb_strcut

### DIFF
--- a/lib/Property.php
+++ b/lib/Property.php
@@ -246,20 +246,9 @@ abstract class Property extends Node {
 
         $str .= ':' . $this->getRawMimeDirValue();
 
-        $out = '';
-        while (($len = \strlen($str)) > 0) {
-            if ($len > 75) {
-                $part = \mb_strcut($str, 0, 75, 'utf-8');
-                $out .= $part . "\r\n";
-                $str = ' ' . \substr($str, \strlen($part));
-            } else {
-                $out .= $str . "\r\n";
-                $str = '';
-                break;
-            }
-        }
+        $str = \preg_replace('/((?:^.)?.{1,74}(?![\x80-\xbf]))/', "$1\r\n ", $str);
 
-        return $out;
+        return \substr($str, 0, -1);
 
     }
 

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -246,8 +246,17 @@ abstract class Property extends Node {
 
         $str .= ':' . $this->getRawMimeDirValue();
 
-        $str = \preg_replace('/((?:^.)?.{1,74}(?![\x80-\xbf]))/', "$1\r\n ", $str);
+        $str = \preg_replace(
+            '/(
+                (?:^.)?         # 1 additional byte in first line because of missing single space (see next line)
+                .{1,74}         # max 75 bytes per line (1 byte is used for a single space added after every CRLF)
+                (?![\x80-\xbf]) # prevent splitting multibyte characters
+            )/x',
+            "$1\r\n ",
+            $str
+        );
 
+        // remove single space after last CRLF
         return \substr($str, 0, -1);
 
     }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -273,8 +273,17 @@ class Text extends Property {
         } else {
             $str .= ':' . $val;
 
-            $str = \preg_replace('/((?:^.)?.{1,74}(?![\x80-\xbf]))/', "$1\r\n ", $str);
+            $str = \preg_replace(
+                '/(
+                    (?:^.)?         # 1 additional byte in first line because of missing single space (see next line)
+                    .{1,74}         # max 75 bytes per line (1 byte is used for a single space added after every CRLF)
+                    (?![\x80-\xbf]) # prevent splitting multibyte characters
+                )/x',
+                "$1\r\n ",
+                $str
+            );
 
+            // remove single space after last CRLF
             return \substr($str, 0, -1);
 
         }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -272,20 +272,10 @@ class Text extends Property {
 
         } else {
             $str .= ':' . $val;
-            $out = '';
-            while (($len = \strlen($str)) > 0) {
-                if ($len > 75) {
-                    $part = \mb_strcut($str, 0, 75, 'utf-8');
-                    $out .= $part . "\r\n";
-                    $str = ' ' . \substr($str, \strlen($part));
-                } else {
-                    $out .= $str . "\r\n";
-                    $str = '';
-                    break;
-                }
-            }
 
-            return $out;
+            $str = \preg_replace('/((?:^.)?.{1,74}(?![\x80-\xbf]))/', "$1\r\n ", $str);
+
+            return \substr($str, 0, -1);
 
         }
 

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -161,9 +161,14 @@ class PropertyTest extends TestCase {
     function testSerializeUTF8LineFold() {
 
         $cal = new VCalendar();
-        $value = str_repeat('!', 65) . "\xc3\xa4bla"; // inserted umlaut-a
+        $value = str_repeat('!', 65) . "\xc3\xa4bla" . str_repeat('!', 142) . "\xc3\xa4foo1"; // inserted umlaut-a
         $property = $cal->createProperty('propname', $value);
-        $expected = "PROPNAME:" . str_repeat('!', 65) . "\r\n \xc3\xa4bla\r\n";
+
+        // PROPNAME:!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ("PROPNAME:" + 65x"!" = 74 bytes)
+        //  äbla!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! (" äbla"     + 69x"!" = 75 bytes)
+        //  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! (" "         + 73x"!" = 74 bytes)
+        //  äfoo
+        $expected = "PROPNAME:" . str_repeat('!', 65) . "\r\n \xc3\xa4bla" . str_repeat('!', 69) . "\r\n " . str_repeat('!', 73) . "\r\n \xc3\xa4foo\r\n";
         $this->assertEquals($expected, $property->serialize());
 
     }

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -161,7 +161,7 @@ class PropertyTest extends TestCase {
     function testSerializeUTF8LineFold() {
 
         $cal = new VCalendar();
-        $value = str_repeat('!', 65) . "\xc3\xa4bla" . str_repeat('!', 142) . "\xc3\xa4foo1"; // inserted umlaut-a
+        $value = str_repeat('!', 65) . "\xc3\xa4bla" . str_repeat('!', 142) . "\xc3\xa4foo"; // inserted umlaut-a
         $property = $cal->createProperty('propname', $value);
 
         // PROPNAME:!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ("PROPNAME:" + 65x"!" = 74 bytes)


### PR DESCRIPTION
thanks to @bwoebi for the regex (I had to adjust it to add a space before each line).

In my case it is much faster:

![screenshot 2018-04-18 12 59 56](https://user-images.githubusercontent.com/330436/38928295-a566a2d0-4308-11e8-84dc-4d507ce1c277.png)
