### PR TITLE
Broker: add timezone to CANCEL messages

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -523,6 +523,11 @@ class Broker {
                 // Creating the new iCalendar body.
                 $icalMsg = new VCalendar();
                 $icalMsg->METHOD = $message->method;
+
+                foreach ($calendar->select('VTIMEZONE') as $timezone) {
+                    $icalMsg->add(clone $timezone);
+                }
+
                 $event = $icalMsg->add('VEVENT', [
                     'UID'      => $message->uid,
                     'SEQUENCE' => $message->sequence,


### PR DESCRIPTION
If DTSTART and/or DTEND and other times are specified with a TZID, some clients
may fail reading the generated iCal data, since the VTIMEZONE definition is
missing.