### PR TITLE
Fixed poor implementations of vCard 3.0 being rejected by server

### DIFF
--- a/lib/Property.php
+++ b/lib/Property.php
@@ -616,7 +616,7 @@ abstract class Property extends Node {
                         $allowedEncoding = ['QUOTED-PRINTABLE', 'BASE64', '8BIT'];
                         break;
                     case Document::VCARD30 :
-                        $allowedEncoding = ['B'];
+                        $allowedEncoding = ['B', 'BASE64'];
                         break;
 
                 }


### PR DESCRIPTION
Let's take an example of the BlackBerry 10 OS.

It shares the vCards in the v3 format, but uses the "BASE64" encoding instead of the "B" one. This results in really odd behaviour in the communication between the sabre server and the BB client  : 

- contact disappearing from both the server and client
- contact being duplicated in the client at each and every synchronisation
- contact losing its name, phone number and/or profile picture
- ...

This PR effectively fixes that issue for each and every OS10 based BlackBerry device, and I assume will fix every client implementation that uses the "BASE64" encoding instead of "B".

I have tested this patch successfully in both sabre standalone and in Nextcloud 12 and 13.
