### PR TITLE
Repairing BASE64 encoded vCard version 3

### DIFF
--- a/lib/Property.php
+++ b/lib/Property.php
@@ -574,9 +574,9 @@ abstract class Property extends Node
                         $allowedEncoding = ['B'];
                         //Repair vCard30 that use BASE64 encoding
                         if ($options & self::REPAIR) {
-                            if ('BASE64' == strtoupper($encoding)) {
+                            if ('BASE64' === strtoupper($encoding)) {
                                 $encoding = 'B';
-                                $this->offsetSet('ENCODING', $encoding);
+                                $this['ENCODING'] = $encoding;
                                 $warnings[] = [
                                     'level' => 1,
                                     'message' => 'ENCODING=BASE64 has been transformed to ENCODING=B.',

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -572,6 +572,18 @@ abstract class Property extends Node
                         break;
                     case Document::VCARD30:
                         $allowedEncoding = ['B'];
+                        //Repair vCard30 that use BASE64 encoding
+                        if ($options & self::REPAIR) {
+                            if ('BASE64' == strtoupper($encoding)) {
+                                $encoding = 'B';
+                                $this->offsetSet('ENCODING', $encoding);
+                                $warnings[] = [
+                                    'level' => 1,
+                                    'message' => 'ENCODING=BASE64 has been transformed to ENCODING=B.',
+                                    'node' => $this,
+                                ];
+                            }
+                        }
                         break;
                 }
                 if ($allowedEncoding && !in_array(strtoupper($encoding), $allowedEncoding)) {

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -368,6 +368,12 @@ class PropertyTest extends TestCase
 
         $this->assertEquals('ENCODING=BASE64 is not valid for this document type.', $result[0]['message']);
         $this->assertEquals(3, $result[0]['level']);
+
+        //Validate the reparation of BASE64 formatted vCard v3
+        $result = $property->validate(Property::REPAIR);
+
+        $this->assertEquals('ENCODING=BASE64 has been transformed to ENCODING=B.', $result[0]['message']);
+        $this->assertEquals(1, $result[0]['level']);
     }
 
     public function testValidateBadEncodingVCard21()


### PR DESCRIPTION
Follow up of
#415

Repairs vCards in V3 that have a BASE64 encoding.