### PR TITLE
docs: Fix typos of it's ▶︎ its, where appropriate.

### DIFF
--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -269,7 +269,7 @@ class VCalendar extends VObject\Document
      * If this calendar object, has events with recurrence rules, this method
      * can be used to expand the event into multiple sub-events.
      *
-     * Each event will be stripped from it's recurrence information, and only
+     * Each event will be stripped from its recurrence information, and only
      * the instances of the event in the specified timerange will be left
      * alone.
      *

--- a/lib/FreeBusyGenerator.php
+++ b/lib/FreeBusyGenerator.php
@@ -71,7 +71,7 @@ class FreeBusyGenerator
     /**
      * A VAVAILABILITY document.
      *
-     * If this is set, it's information will be included when calculating
+     * If this is set, its information will be included when calculating
      * freebusy time.
      *
      * @var Document

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -29,7 +29,7 @@ class Parameter extends Node
     /**
      * vCard 2.1 allows parameters to be encoded without a name.
      *
-     * We can deduce the parameter name based on it's value.
+     * We can deduce the parameter name based on its value.
      *
      * @var bool
      */

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -415,7 +415,7 @@ class MimeDir extends Parser
         }
 
         // vCard 2.1 states that parameters may appear without a name, and only
-        // a value. We can deduce the value based on it's name.
+        // a value. We can deduce the value based on its name.
         //
         // Our parser will get those as parameters without a value instead, so
         // we're filtering these parameters out first.

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -155,7 +155,7 @@ abstract class Property extends Node
      *
      * If a parameter with same name already existed, the values will be
      * combined.
-     * If nameless parameter is added, we try to guess it's name.
+     * If nameless parameter is added, we try to guess its name.
      *
      * @param string            $name
      * @param string|null|array $value

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -55,7 +55,7 @@ class Reader
      * The options argument is a bitfield. Pass any of the OPTIONS constant to
      * alter the parsers' behaviour.
      *
-     * You can either a string, a readable stream, or an array for it's input.
+     * You can either a string, a readable stream, or an array for its input.
      * Specifying the array is useful if json_decode was already called on the
      * input.
      *

--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -237,7 +237,7 @@ class EventIterator implements \Iterator
     /**
      * Returns a VEVENT for the current iterations of the event.
      *
-     * This VEVENT will have a recurrence id, and it's DTSTART and DTEND
+     * This VEVENT will have a recurrence id, and its DTSTART and DTEND
      * altered.
      *
      * @return VEvent

--- a/lib/Splitter/ICalendar.php
+++ b/lib/Splitter/ICalendar.php
@@ -38,7 +38,7 @@ class ICalendar implements SplitterInterface
     /**
      * Constructor.
      *
-     * The splitter should receive an readable file stream as it's input.
+     * The splitter should receive an readable file stream as its input.
      *
      * @param resource $input
      * @param int      $options parser options, see the OPTIONS constants

--- a/lib/Splitter/SplitterInterface.php
+++ b/lib/Splitter/SplitterInterface.php
@@ -20,7 +20,7 @@ interface SplitterInterface
     /**
      * Constructor.
      *
-     * The splitter should receive an readable file stream as it's input.
+     * The splitter should receive an readable file stream as its input.
      *
      * @param resource $input
      */

--- a/lib/Splitter/VCard.php
+++ b/lib/Splitter/VCard.php
@@ -38,7 +38,7 @@ class VCard implements SplitterInterface
     /**
      * Constructor.
      *
-     * The splitter should receive an readable file stream as it's input.
+     * The splitter should receive an readable file stream as its input.
      *
      * @param resource $input
      * @param int      $options parser options, see the OPTIONS constants


### PR DESCRIPTION
Fix minor typos throughout docstrings.