### PR TITLE
Preventing creating a component for a root document

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -195,6 +195,10 @@ class MimeDir extends Parser
     {
         // Start of a new component
         if ('BEGIN:' === strtoupper(substr($line, 0, 6))) {
+
+            if (substr($line, 6) === $this->root->name) {
+                throw new ParseException('Invalid MimeDir file. Unexpected component: "' . $line . '" in document type ' . $this->root->name);
+            }
             $component = $this->root->createComponent(substr($line, 6), [], false);
 
             while (true) {

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -195,9 +195,8 @@ class MimeDir extends Parser
     {
         // Start of a new component
         if ('BEGIN:' === strtoupper(substr($line, 0, 6))) {
-
             if (substr($line, 6) === $this->root->name) {
-                throw new ParseException('Invalid MimeDir file. Unexpected component: "' . $line . '" in document type ' . $this->root->name);
+                throw new ParseException('Invalid MimeDir file. Unexpected component: "'.$line.'" in document type '.$this->root->name);
             }
             $component = $this->root->createComponent(substr($line, 6), [], false);
 

--- a/tests/VObject/Splitter/VCardTest.php
+++ b/tests/VObject/Splitter/VCardTest.php
@@ -101,8 +101,8 @@ EOT;
     }
 
     /**
-    * @expectedException \Sabre\VObject\ParseException
-    */
+     * @expectedException \Sabre\VObject\ParseException
+     */
     public function testVCardImportVCardNoComponent()
     {
         $data = <<<EOT

--- a/tests/VObject/Splitter/VCardTest.php
+++ b/tests/VObject/Splitter/VCardTest.php
@@ -100,6 +100,29 @@ EOT;
         $this->assertEquals(4, $count);
     }
 
+    /**
+    * @expectedException \Sabre\VObject\ParseException
+    */
+    public function testVCardImportVCardNoComponent()
+    {
+        $data = <<<EOT
+BEGIN:VCARD
+FN:first card
+
+BEGIN:VCARD
+FN:ok
+END:VCARD
+EOT;
+        $tempFile = $this->createStream($data);
+
+        $splitter = new VCard($tempFile);
+
+        $this->expectException(\Sabre\VObject\ParseException::class);
+        $this->expectExceptionMessage('Invalid MimeDir file. Unexpected component: "BEGIN:VCARD" in document type VCARD');
+        while ($object = $splitter->getNext()) {
+        }
+    }
+
     public function testVCardImportEndOfData()
     {
         $data = <<<EOT


### PR DESCRIPTION
When parsing a vcard file, I've got this [error](https://sentry.io/share/issue/ff63a781a8184391bf127a5a7f90a46f/):
```
Argument 3 passed to Sabre\VObject\Component::__construct() must be of the type array, string given
#40 /vendor/sabre/vobject/lib/Component.php(53): Sabre\VObject\Component::__construct
#39 [internal](0): call_user_func_array
#38 /vendor/sabre/vobject/lib/Document.php(105): Sabre\VObject\Document::__construct
#37 /vendor/sabre/vobject/lib/Document.php(175): Sabre\VObject\Document::createComponent
#36 /vendor/sabre/vobject/lib/Parser/MimeDir.php(208): Sabre\VObject\Parser\MimeDir::parseLine
#35 /vendor/sabre/vobject/lib/Parser/MimeDir.php(181): Sabre\VObject\Parser\MimeDir::parseDocument
#34 /vendor/sabre/vobject/lib/Parser/MimeDir.php(89): Sabre\VObject\Parser\MimeDir::parse
#33 /vendor/sabre/vobject/lib/Splitter/VCard.php(64): Sabre\VObject\Splitter\VCard::getNext
...
```
Parameters passed to Document::__construct are
```
[
   Object Sabre\VObject\Component\VCard,
   VCARD,
   [],
   false
]
```
This should not happen.

I think this could happen when the "END:VCARD" is not detected. Then the next "BEGIN:VCARD" of the file is used in `MimeDir::parseLine` and detected as a new *component*, but VCARD is not a component, and this leads to this bug.

To prevent this error, we can simply throw a ParseException. Unfortunatly the next vcard will not be parsed, until a new "BEGIN:VCARD" line is read.

