### PR TITLE
Fix parse with option Forgiving with trailing equal

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -655,7 +655,7 @@ class MimeDir extends Parser
         // missing a whitespace. So if 'forgiving' is turned on, we will take
         // those as well.
         if ($this->options & self::OPTION_FORGIVING) {
-            while ('=' === substr($value, -1)) {
+            while ('=' === substr($value, -1) && $this->lineBuffer) {
                 // Reading the line
                 $this->readLine();
                 // Grabbing the raw form

--- a/tests/VObject/Splitter/VCardTest.php
+++ b/tests/VObject/Splitter/VCardTest.php
@@ -100,6 +100,29 @@ EOT;
         $this->assertEquals(4, $count);
     }
 
+    public function testVCardImportQuotedPrintableOptionForgivingLeading()
+    {
+        $data = <<<EOT
+BEGIN:VCARD
+FN;card
+TITLE;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=D0=
+
+END:VCARD
+BEGIN:VCARD
+FN;card
+END:VCARD
+EOT;
+        $tempFile = $this->createStream($data);
+
+        $splitter = new VCard($tempFile, \Sabre\VObject\Parser\Parser::OPTION_FORGIVING);
+
+        $count = 0;
+        while ($object = $splitter->getNext()) {
+            ++$count;
+        }
+        $this->assertEquals(2, $count);
+    }
+
     public function testVCardImportEndOfData()
     {
         $data = <<<EOT


### PR DESCRIPTION
When using option Forgiving, if a quoted printable line ends with an equal sign, followed by en empty line, there will be a parse error.
In this case, the `readLine` must not be called again.