### PR TITLE
fixed typo in VCalendar which resulting in usage of the wrong TimeZone

### DIFF
--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -336,7 +336,7 @@ class VCalendar extends VObject\Document
 
         foreach ($recurringEvents as $events) {
             try {
-                $it = new EventIterator($events, $timeZone);
+                $it = new EventIterator($events, null, $timeZone);
             } catch (NoInstancesException $e) {
                 // This event is recurring, but it doesn't have a single
                 // instance. We are skipping this event from the output


### PR DESCRIPTION
I‘ve found a bug. The creation of the new EventIterator must have the reference timezone on the third position. But ist was submitted at the second. I’ve added a null to the second position an now it works.

Could you pull these changes please?