### PR TITLE
fix phpstan level1 warnings

### DIFF
--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -14,9 +14,9 @@ use Sabre\VObject;
  * @author Ivan Enderlin
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property \DateTime $DTSTART
+ * @property \DateTime      $DTSTART
  * @property \DateTime|null $DTEND
- * @property mixed $DURATION
+ * @property mixed          $DURATION
  */
 class Available extends VObject\Component
 {

--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -13,6 +13,9 @@ use Sabre\VObject;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Ivan Enderlin
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property $DTSTART
+ * @property $DURATION
  */
 class Available extends VObject\Component
 {

--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -14,8 +14,9 @@ use Sabre\VObject;
  * @author Ivan Enderlin
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property $DTSTART
- * @property $DURATION
+ * @property \DateTime $DTSTART
+ * @property \DateTime|null $DTEND
+ * @property mixed $DURATION
  */
 class Available extends VObject\Component
 {

--- a/lib/Component/VAlarm.php
+++ b/lib/Component/VAlarm.php
@@ -16,11 +16,11 @@ use Sabre\VObject\InvalidDataException;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property mixed $ACTION
+ * @property mixed           $ACTION
  * @property array|\DateTime $TRIGGER
- * @property mixed|null $DURATION
- * @property string|null $REPEAT
- * @property mixed|null $ATTACH
+ * @property mixed|null      $DURATION
+ * @property string|null     $REPEAT
+ * @property mixed|null      $ATTACH
  */
 class VAlarm extends VObject\Component
 {

--- a/lib/Component/VAlarm.php
+++ b/lib/Component/VAlarm.php
@@ -15,6 +15,12 @@ use Sabre\VObject\InvalidDataException;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property mixed $ACTION
+ * @property array|\DateTime $TRIGGER
+ * @property mixed|null $DURATION
+ * @property string|null $REPEAT
+ * @property mixed|null $ATTACH
  */
 class VAlarm extends VObject\Component
 {

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -19,6 +19,9 @@ use Sabre\VObject\Recur\NoInstancesException;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property string $VERSION
+ * @property string $PRODID
  */
 class VCalendar extends VObject\Document
 {

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -14,6 +14,8 @@ use Sabre\Xml;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property string $VERSION 
  */
 class VCard extends VObject\Document
 {

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -15,7 +15,9 @@ use Sabre\Xml;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property string $VERSION 
+ * @property string $UID
+ * @property string $VERSION
+ * @property string $FN
  */
 class VCard extends VObject\Document
 {

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -16,7 +16,7 @@ use Sabre\VObject\Recur\NoInstancesException;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property mixed|null $RRULE
+ * @property mixed|null     $RRULE
  * @property \DateTime|null $DTSTART
  * @property \DateTime|null $DTEND
  */

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -15,6 +15,10 @@ use Sabre\VObject\Recur\NoInstancesException;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property mixed|null $RRULE
+ * @property \DateTime|null $DTSTART
+ * @property \DateTime|null $DTEND
  */
 class VEvent extends VObject\Component
 {

--- a/lib/Component/VJournal.php
+++ b/lib/Component/VJournal.php
@@ -13,6 +13,8 @@ use Sabre\VObject;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property \DateTime|null $DTSTART 
  */
 class VJournal extends VObject\Component
 {

--- a/lib/Component/VJournal.php
+++ b/lib/Component/VJournal.php
@@ -14,7 +14,7 @@ use Sabre\VObject;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  *
- * @property \DateTime|null $DTSTART 
+ * @property \DateTime|null $DTSTART
  */
 class VJournal extends VObject\Component
 {

--- a/lib/Component/VTimeZone.php
+++ b/lib/Component/VTimeZone.php
@@ -13,6 +13,8 @@ use Sabre\VObject;
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
+ *
+ * @property string $TZID
  */
 class VTimeZone extends VObject\Component
 {

--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -343,6 +343,7 @@ class DateTime extends Property
         $messages = parent::validate($options);
         $valueType = $this->getValueType();
         $values = $this->getParts();
+        $value = null; // init to a artifical value, to prevent phpstan warning 'might not be defined'
         try {
             foreach ($values as $value) {
                 switch ($valueType) {

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -324,7 +324,7 @@ class RRuleIterator implements Iterator
 
             return;
         }
-        
+
         $recurrenceHours = array();
         if (!empty($this->byHour)) {
             $recurrenceHours = $this->getHours();

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -444,6 +444,7 @@ class RRuleIterator implements Iterator
             return;
         }
 
+        $occurrence = -1; // init to a artifical value, to prevent phpstan warning 'might not be defined'
         while (true) {
             $occurrences = $this->getMonthlyOccurrences();
 
@@ -609,6 +610,7 @@ class RRuleIterator implements Iterator
         $currentDayOfMonth = $this->currentDate->format('j');
 
         $advancedToNewMonth = false;
+        $occurrence = -1; // init to a artifical value, to prevent phpstan warning 'might not be defined'
 
         // If we got a byDay or getMonthDay filter, we must first expand
         // further.

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -324,15 +324,18 @@ class RRuleIterator implements Iterator
 
             return;
         }
-
+        
+        $recurrenceHours = array();
         if (!empty($this->byHour)) {
             $recurrenceHours = $this->getHours();
         }
 
+        $recurrenceDays = array();
         if (!empty($this->byDay)) {
             $recurrenceDays = $this->getDays();
         }
 
+        $recurrenceMonths = array();
         if (!empty($this->byMonth)) {
             $recurrenceMonths = $this->getMonths();
         }
@@ -375,10 +378,12 @@ class RRuleIterator implements Iterator
             return;
         }
 
+        $recurrenceHours = array();
         if ($this->byHour) {
             $recurrenceHours = $this->getHours();
         }
 
+        $recurrenceDays = array();
         if ($this->byDay) {
             $recurrenceDays = $this->getDays();
         }


### PR DESCRIPTION
after we fixed these warnings php IDEs can get smarter about the classes runtime properties and also other static analysis tools can make better assumptions/decisions.

primary goal of this PR is fixing the phpstan level1 warnings (therefore a green build), not defining all possible properties. I dont have enough knowledge to do this.