### PR TITLE
fix  Bad file descriptor (7.4)

### DIFF
--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -16,7 +16,7 @@ class MimeDirTest extends TestCase
     public function testParseError()
     {
         $mimeDir = new MimeDir();
-        $mimeDir->parse(fopen(__FILE__, 'a'));
+        $mimeDir->parse(fopen(__FILE__, 'a+'));
     }
 
     public function testDecodeLatin1()


### PR DESCRIPTION
With 7.4.0RC3
```
There was 1 error:

1) Sabre\VObject\Parser\MimeDirTest::testParseError
fgets(): read of 8192 bytes failed with errno=9 Bad file descriptor

```

This minimal fix open file in read/write mode, to avoid the new warning.

A better fix will be to detect if the stream is properly open for read in setInput 
```
 is_resource 
 get_resource_type == "stream"
 stream_get_meta_data => "mode"
``` 
But this will be a new feature, so far away for the goal of this simple fix.