### PR TITLE
Add PHONE-NUMBER value type (used for TEL in vCard 3.0)

### DIFF
--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -57,6 +57,7 @@ class VCard extends VObject\Document
         'FLOAT' => 'Sabre\\VObject\\Property\\FloatValue',
         'INTEGER' => 'Sabre\\VObject\\Property\\IntegerValue',
         'LANGUAGE-TAG' => 'Sabre\\VObject\\Property\\VCard\\LanguageTag',
+        'PHONE-NUMBER' => 'Sabre\\VObject\\Property\\VCard\\PhoneNumber', // vCard 3.0 only
         'TIMESTAMP' => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
         'TEXT' => 'Sabre\\VObject\\Property\\Text',
         'TIME' => 'Sabre\\VObject\\Property\\Time',

--- a/lib/Property/VCard/PhoneNumber.php
+++ b/lib/Property/VCard/PhoneNumber.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Sabre\VObject\Property\VCard;
+
+use Sabre\VObject\Property;
+
+/**
+ * PhoneNumber property.
+ *
+ * This object encodes PHONE-NUMBER values.
+ *
+ * @author Christian Kraus <christian@kraus.work>
+ */
+class PhoneNumber extends Property\Text
+{
+    protected $structuredValues = [];
+
+    /**
+     * Returns the type of value.
+     *
+     * This corresponds to the VALUE= parameter. Every property also has a
+     * 'default' valueType.
+     *
+     * @return string
+     */
+    public function getValueType()
+    {
+        return 'PHONE-NUMBER';
+    }
+}

--- a/lib/VCardConverter.php
+++ b/lib/VCardConverter.php
@@ -83,6 +83,9 @@ class VCardConverter
         if (!$valueType) {
             $valueType = $property->getValueType();
         }
+        if (Document::VCARD30 !== $targetVersion && 'PHONE-NUMBER' === $valueType) {
+            $valueType = null;
+        }
         $newProperty = $output->createProperty(
             $property->name,
             $property->getParts(),

--- a/tests/VObject/Property/VCard/PhoneNumberTest.php
+++ b/tests/VObject/Property/VCard/PhoneNumberTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sabre\VObject\Property\VCard;
+
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject;
+
+class PhoneNumberTest extends TestCase
+{
+    public function testParser()
+    {
+        $input = "BEGIN:VCARD\r\nVERSION:3.0\r\nTEL;TYPE=HOME;VALUE=PHONE-NUMBER:+1234\r\nEND:VCARD\r\n";
+
+        $vCard = VObject\Reader::read($input);
+        $this->assertInstanceOf('Sabre\VObject\Property\VCard\PhoneNumber', $vCard->TEL);
+        $this->assertEquals('PHONE-NUMBER', $vCard->TEL->getValueType());
+        $this->assertEquals($input, $vCard->serialize());
+    }
+}

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -518,4 +518,34 @@ VCF;
 
         $this->assertEquals($expected, str_replace("\r", '', $vcard));
     }
+
+    public function testPhoneNumberValueTypeGetsRemoved()
+    {
+        $input = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+UID:foo
+FN:John Doe
+TEL;TYPE=HOME;VALUE=PHONE-NUMBER:+1234
+END:VCARD
+
+VCF;
+
+        $output = <<<VCF
+BEGIN:VCARD
+VERSION:4.0
+UID:foo
+FN:John Doe
+TEL;TYPE=HOME:+1234
+END:VCARD
+VCF;
+
+        $vcard = Reader::read($input);
+        $vcard = $vcard->convert(Document::VCARD40);
+
+        $this->assertVObjectEqualsVObject(
+            $output,
+            $vcard
+        );
+    }
 }


### PR DESCRIPTION
In vCard 3.0, `TEL` value should be of type `PHONE-NUMBER` ([Section 2.4.3](https://tools.ietf.org/html/rfc2426#section-2.4.3) / [Section 3.3.1](https://tools.ietf.org/html/rfc2426#section-3.3.1)).

So the following _should_ be a valid vCard:

```
BEGIN:VCARD
VERSION:3.0
TEL;TYPE=HOME;VALUE=PHONE-NUMBER:+123456789
END:VCARD
```

vObject currently throws an Exception when trying to parse that.

This PR adds the value type, and also throws it out when converting to vCard 4 (which expects `URI` type).