### PR TITLE
Update dependencies and code style tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ tests/temp
 
 #binaries
 bin/phpunit
-bin/phpcs
 bin/php-cs-fixer
-bin/sabre-cs-fixer
+bin/phpstan
+bin/phpstan.phar
 bin/hoa
 
 # Development stuff

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,7 +6,7 @@ $config->getFinder()
     ->in(__DIR__);
 $config->setRules([
     '@PSR1' => true,
-    '@Symfony' =>true
+    '@Symfony' => true
 ]);
 
 return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -10,17 +7,15 @@ php:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: 5.5
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^7\.1|7\.2|7\.3|7\.4$ ]]; then wget https://github.com/phpstan/phpstan/releases/download/0.12.5/phpstan.phar; fi
+  - composer require --dev phpstan/phpstan:^0.12
 
 before_script:
   - composer install
 
 script:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^7\.1|7\.2|7\.3|7\.4$ ]]; then php phpstan.phar analyse -c phpstan.neon lib tests; fi
+  - php ./bin/phpstan.phar analyse -c phpstan.neon lib tests
   - ./bin/phpunit --configuration tests/phpunit.xml --coverage-clover=coverage.xml
   
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,13 @@
     "homepage" : "http://sabre.io/vobject/",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php"          : ">=5.5",
+        "php"          : "^7.1",
         "ext-mbstring" : "*",
-        "sabre/xml"    : ">=1.5 <3.0"
+        "sabre/xml"    : "^2.1"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "> 4.8.35, <6.0.0"
+        "friendsofphp/php-cs-fixer": "2.16.*",
+        "phpunit/phpunit" : "^7"
     },
     "suggest" : {
         "hoa/bench"       : "If you would like to run the benchmark scripts"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,2 @@
 parameters:
   level: 0
-  bootstrap: %currentWorkingDirectory%/vendor/autoload.php

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -6,11 +6,12 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="true"
   beStrictAboutOutputDuringTests="true"
-  beStrictAboutTestSize="true"
   >
-  <testsuite name="Sabre\VObject">
-    <directory>VObject/</directory>
-  </testsuite>
+  <testsuites>
+    <testsuite name="Sabre\VObject">
+      <directory>VObject/</directory>
+    </testsuite>
+  </testsuites>
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
1) require PHP 7.1 or later and phpunit 7
2) test on only PHP 7.1 through 7.4

Note 1: CI currently runs `phpstan` - good stuff and it passes at the current level 0.

Note 2: there is already a config for `php-cs-fixer` but it is not running in CI. There are lots of edits that it wants to make. I will do that in a separate PR #492  because maybe nobody wants to apply such a lot of changes.
