### PR TITLE
Apply code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - composer install
 
 script:
+  - ./bin/php-cs-fixer fix lib/ --dry-run --diff
   - php ./bin/phpstan.phar analyse -c phpstan.neon lib tests
   - ./bin/phpunit --configuration tests/phpunit.xml --coverage-clover=coverage.xml
   

--- a/lib/Cli.php
+++ b/lib/Cli.php
@@ -312,8 +312,6 @@ HELP
     /**
      * Validates a VObject file.
      *
-     * @param Component $vObj
-     *
      * @return int
      */
     protected function validate(Component $vObj)
@@ -353,8 +351,6 @@ HELP
 
     /**
      * Repairs a VObject file.
-     *
-     * @param Component $vObj
      *
      * @return int
      */
@@ -582,8 +578,6 @@ HELP
 
     /**
      * Colorizes a property.
-     *
-     * @param Property $property
      */
     protected function serializeProperty(Property $property)
     {
@@ -642,8 +636,6 @@ HELP
 
     /**
      * Parses the list of arguments.
-     *
-     * @param array $argv
      */
     protected function parseArguments(array $argv)
     {

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -43,10 +43,8 @@ class Component extends Node
      * an iCalendar object, this may be something like CALSCALE:GREGORIAN. To
      * ensure that this does not happen, set $defaults to false.
      *
-     * @param Document $root
-     * @param string   $name     such as VCALENDAR, VEVENT
-     * @param array    $children
-     * @param bool     $defaults
+     * @param string $name     such as VCALENDAR, VEVENT
+     * @param bool   $defaults
      */
     public function __construct(Document $root, $name, array $children = [], $defaults = true)
     {

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -26,9 +26,6 @@ class VAvailability extends VObject\Component
      *
      * https://tools.ietf.org/html/draft-daboo-calendar-availability-05#section-3.1
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     *
      * @return bool
      */
     public function isInTimeRange(DateTimeInterface $start, DateTimeInterface $end)

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -276,10 +276,8 @@ class VCalendar extends VObject\Document
      * In addition, this method will cause timezone information to be stripped,
      * and normalized to UTC.
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     * @param DateTimeZone      $timeZone reference timezone for floating dates and
-     *                                    times
+     * @param DateTimeZone $timeZone reference timezone for floating dates and
+     *                               times
      *
      * @return VCalendar
      */

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -25,9 +25,6 @@ class VEvent extends VObject\Component
      * The rules used to determine if an event falls within the specified
      * time-range is based on the CalDAV specification.
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     *
      * @return bool
      */
     public function isInTimeRange(DateTimeInterface $start, DateTimeInterface $end)

--- a/lib/Component/VFreeBusy.php
+++ b/lib/Component/VFreeBusy.php
@@ -21,9 +21,6 @@ class VFreeBusy extends VObject\Component
      * Checks based on the contained FREEBUSY information, if a timeslot is
      * available.
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     *
      * @return bool
      */
     public function isFree(DateTimeInterface $start, DatetimeInterface $end)

--- a/lib/Component/VJournal.php
+++ b/lib/Component/VJournal.php
@@ -23,9 +23,6 @@ class VJournal extends VObject\Component
      * The rules used to determine if an event falls within the specified
      * time-range is based on the CalDAV specification.
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     *
      * @return bool
      */
     public function isInTimeRange(DateTimeInterface $start, DateTimeInterface $end)

--- a/lib/Component/VTodo.php
+++ b/lib/Component/VTodo.php
@@ -23,9 +23,6 @@ class VTodo extends VObject\Component
      * The rules used to determine if an event falls within the specified
      * time-range is based on the CalDAV specification.
      *
-     * @param DateTimeInterface $start
-     * @param DateTimeInterface $end
-     *
      * @return bool
      */
     public function isInTimeRange(DateTimeInterface $start, DateTimeInterface $end)

--- a/lib/FreeBusyGenerator.php
+++ b/lib/FreeBusyGenerator.php
@@ -109,8 +109,6 @@ class FreeBusyGenerator
      * for setting things like the METHOD, CALSCALE, VERSION, etc..
      *
      * The VFREEBUSY object will be automatically added though.
-     *
-     * @param Document $vcalendar
      */
     public function setBaseObject(Document $vcalendar)
     {
@@ -119,8 +117,6 @@ class FreeBusyGenerator
 
     /**
      * Sets a VAVAILABILITY document.
-     *
-     * @param Document $vcalendar
      */
     public function setVAvailability(Document $vcalendar)
     {
@@ -176,8 +172,6 @@ class FreeBusyGenerator
 
     /**
      * Sets the reference timezone for floating times.
-     *
-     * @param DateTimeZone $timeZone
      */
     public function setTimeZone(DateTimeZone $timeZone)
     {
@@ -208,9 +202,6 @@ class FreeBusyGenerator
     /**
      * This method takes a VAVAILABILITY component and figures out all the
      * available times.
-     *
-     * @param FreeBusyData $fbData
-     * @param VCalendar    $vavailability
      */
     protected function calculateAvailability(FreeBusyData $fbData, VCalendar $vavailability)
     {
@@ -363,8 +354,7 @@ class FreeBusyGenerator
      * This method takes an array of iCalendar objects and applies its busy
      * times on fbData.
      *
-     * @param FreeBusyData $fbData
-     * @param VCalendar[]  $objects
+     * @param VCalendar[] $objects
      */
     protected function calculateBusy(FreeBusyData $fbData, array $objects)
     {

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -104,7 +104,6 @@ class Broker
      *
      * If the iTip message was not supported, we will always return false.
      *
-     * @param Message   $itipMessage
      * @param VCalendar $existingObject
      *
      * @return VCalendar|null
@@ -263,8 +262,6 @@ class Broker
      * This is message from an organizer, and is either a new event
      * invite, or an update to an existing one.
      *
-     *
-     * @param Message   $itipMessage
      * @param VCalendar $existingObject
      *
      * @return VCalendar|null
@@ -300,7 +297,6 @@ class Broker
      * attendee got removed from an event, or an event got cancelled
      * altogether.
      *
-     * @param Message   $itipMessage
      * @param VCalendar $existingObject
      *
      * @return VCalendar|null
@@ -326,7 +322,6 @@ class Broker
      * The message is a reply. This is for example an attendee telling
      * an organizer he accepted the invite, or declined it.
      *
-     * @param Message   $itipMessage
      * @param VCalendar $existingObject
      *
      * @return VCalendar|null
@@ -451,10 +446,6 @@ class Broker
      *
      * We will detect which attendees got added, which got removed and create
      * specific messages for these situations.
-     *
-     * @param VCalendar $calendar
-     * @param array     $eventInfo
-     * @param array     $oldEventInfo
      *
      * @return array
      */
@@ -620,10 +611,7 @@ class Broker
      *
      * This function figures out if we need to send a reply to an organizer.
      *
-     * @param VCalendar $calendar
-     * @param array     $eventInfo
-     * @param array     $oldEventInfo
-     * @param string    $attendee
+     * @param string $attendee
      *
      * @return Message[]
      */

--- a/lib/Node.php
+++ b/lib/Node.php
@@ -115,8 +115,6 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * Sets the overridden iterator.
      *
      * Note that this is not actually part of the iterator interface
-     *
-     * @param ElementList $iterator
      */
     public function setIterator(ElementList $iterator)
     {

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -201,8 +201,6 @@ class Parameter extends Node
 
     /**
      * Sets multiple values for this parameter.
-     *
-     * @param array $value
      */
     public function setParts(array $value)
     {

--- a/lib/Parser/Json.php
+++ b/lib/Parser/Json.php
@@ -87,8 +87,6 @@ class Json extends Parser
     /**
      * Parses a component.
      *
-     * @param array $jComp
-     *
      * @return \Sabre\VObject\Component
      */
     public function parseComponent(array $jComp)
@@ -123,8 +121,6 @@ class Json extends Parser
 
     /**
      * Parses properties.
-     *
-     * @param array $jProp
      *
      * @return \Sabre\VObject\Property
      */

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -112,8 +112,6 @@ class XML extends Parser
 
     /**
      * Parse a xCalendar component.
-     *
-     * @param Component $parentComponent
      */
     protected function parseVCalendarComponents(Component $parentComponent)
     {
@@ -134,8 +132,6 @@ class XML extends Parser
 
     /**
      * Parse a xCard component.
-     *
-     * @param Component $parentComponent
      */
     protected function parseVCardComponents(Component $parentComponent)
     {
@@ -146,8 +142,7 @@ class XML extends Parser
     /**
      * Parse xCalendar and xCard properties.
      *
-     * @param Component $parentComponent
-     * @param string    $propertyNamePrefix
+     * @param string $propertyNamePrefix
      */
     protected function parseProperties(Component $parentComponent, $propertyNamePrefix = '')
     {
@@ -302,8 +297,6 @@ class XML extends Parser
 
     /**
      * Parse a component.
-     *
-     * @param Component $parentComponent
      */
     protected function parseComponent(Component $parentComponent)
     {
@@ -327,11 +320,10 @@ class XML extends Parser
     /**
      * Create a property.
      *
-     * @param Component $parentComponent
-     * @param string    $name
-     * @param array     $parameters
-     * @param string    $type
-     * @param mixed     $value
+     * @param string $name
+     * @param array  $parameters
+     * @param string $type
+     * @param mixed  $value
      */
     protected function createProperty(Component $parentComponent, $name, $parameters, $type, $value)
     {

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -123,8 +123,6 @@ abstract class Property extends Node
 
     /**
      * Sets a multi-valued property.
-     *
-     * @param array $parts
      */
     public function setParts(array $parts)
     {
@@ -262,8 +260,6 @@ abstract class Property extends Node
      * Sets the JSON value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {
@@ -309,8 +305,6 @@ abstract class Property extends Node
     /**
      * Hydrate data from a XML subtree, as it would appear in a xCard or xCal
      * object.
-     *
-     * @param array $value
      */
     public function setXmlValue(array $value)
     {

--- a/lib/Property/Binary.php
+++ b/lib/Property/Binary.php
@@ -100,8 +100,6 @@ class Binary extends Property
      * Sets the json value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {

--- a/lib/Property/Boolean.php
+++ b/lib/Property/Boolean.php
@@ -59,8 +59,6 @@ class Boolean extends Property
     /**
      * Hydrate data from a XML subtree, as it would appear in a xCard or xCal
      * object.
-     *
-     * @param array $value
      */
     public function setXmlValue(array $value)
     {

--- a/lib/Property/FloatValue.php
+++ b/lib/Property/FloatValue.php
@@ -93,8 +93,6 @@ class FloatValue extends Property
     /**
      * Hydrate data from a XML subtree, as it would appear in a xCard or xCal
      * object.
-     *
-     * @param array $value
      */
     public function setXmlValue(array $value)
     {

--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -38,8 +38,6 @@ class DateTime extends Property
      * Sets a multi-valued property.
      *
      * You may also specify DateTime objects here.
-     *
-     * @param array $parts
      */
     public function setParts(array $parts)
     {
@@ -175,7 +173,6 @@ class DateTime extends Property
     /**
      * Sets the property as a DateTime object.
      *
-     * @param DateTimeInterface $dt
      * @param bool isFloating If set to true, timezones will be ignored
      */
     public function setDateTime(DateTimeInterface $dt, $isFloating = false)
@@ -279,8 +276,6 @@ class DateTime extends Property
      * Sets the json value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {

--- a/lib/Property/ICalendar/Period.php
+++ b/lib/Property/ICalendar/Period.php
@@ -67,8 +67,6 @@ class Period extends Property
      * Sets the json value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {

--- a/lib/Property/ICalendar/Recur.php
+++ b/lib/Property/ICalendar/Recur.php
@@ -88,8 +88,6 @@ class Recur extends Property
 
     /**
      * Sets a multi-valued property.
-     *
-     * @param array $parts
      */
     public function setParts(array $parts)
     {

--- a/lib/Property/IntegerValue.php
+++ b/lib/Property/IntegerValue.php
@@ -68,8 +68,6 @@ class IntegerValue extends Property
     /**
      * Hydrate data from a XML subtree, as it would appear in a xCard or xCal
      * object.
-     *
-     * @param array $value
      */
     public function setXmlValue(array $value)
     {

--- a/lib/Property/Time.php
+++ b/lib/Property/Time.php
@@ -40,8 +40,6 @@ class Time extends Text
      * Sets the JSON value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {
@@ -119,8 +117,6 @@ class Time extends Text
     /**
      * Hydrate data from a XML subtree, as it would appear in a xCard or xCal
      * object.
-     *
-     * @param array $value
      */
     public function setXmlValue(array $value)
     {

--- a/lib/Property/UtcOffset.php
+++ b/lib/Property/UtcOffset.php
@@ -38,8 +38,6 @@ class UtcOffset extends Text
      * Sets the JSON value, as it would appear in a jCard or jCal object.
      *
      * The value must always be an array.
-     *
-     * @param array $value
      */
     public function setJsonValue(array $value)
     {

--- a/lib/Property/VCard/Date.php
+++ b/lib/Property/VCard/Date.php
@@ -28,8 +28,6 @@ class Date extends DateAndOrTime
 
     /**
      * Sets the property as a DateTime object.
-     *
-     * @param \DateTimeInterface $dt
      */
     public function setDateTime(\DateTimeInterface $dt)
     {

--- a/lib/Property/VCard/DateAndOrTime.php
+++ b/lib/Property/VCard/DateAndOrTime.php
@@ -45,8 +45,6 @@ class DateAndOrTime extends Property
      * Sets a multi-valued property.
      *
      * You may also specify DateTimeInterface objects here.
-     *
-     * @param array $parts
      */
     public function setParts(array $parts)
     {
@@ -80,8 +78,6 @@ class DateAndOrTime extends Property
 
     /**
      * Sets the property as a DateTime object.
-     *
-     * @param DateTimeInterface $dt
      */
     public function setDateTime(DateTimeInterface $dt)
     {

--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -380,8 +380,6 @@ class EventIterator implements \Iterator
 
     /**
      * Quickly jump to a date in the future.
-     *
-     * @param DateTimeInterface $dateTime
      */
     public function fastForward(DateTimeInterface $dateTime)
     {

--- a/lib/Recur/RDateIterator.php
+++ b/lib/Recur/RDateIterator.php
@@ -24,8 +24,7 @@ class RDateIterator implements Iterator
     /**
      * Creates the Iterator.
      *
-     * @param string|array      $rrule
-     * @param DateTimeInterface $start
+     * @param string|array $rrule
      */
     public function __construct($rrule, DateTimeInterface $start)
     {
@@ -107,8 +106,6 @@ class RDateIterator implements Iterator
     /**
      * This method allows you to quickly go to the next occurrence after the
      * specified date.
-     *
-     * @param DateTimeInterface $dt
      */
     public function fastForward(DateTimeInterface $dt)
     {

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -27,8 +27,7 @@ class RRuleIterator implements Iterator
     /**
      * Creates the Iterator.
      *
-     * @param string|array      $rrule
-     * @param DateTimeInterface $start
+     * @param string|array $rrule
      */
     public function __construct($rrule, DateTimeInterface $start)
     {
@@ -132,8 +131,6 @@ class RRuleIterator implements Iterator
     /**
      * This method allows you to quickly go to the next occurrence after the
      * specified date.
-     *
-     * @param DateTimeInterface $dt
      */
     public function fastForward(DateTimeInterface $dt)
     {

--- a/lib/VCardConverter.php
+++ b/lib/VCardConverter.php
@@ -26,8 +26,7 @@ class VCardConverter
      *
      * If input and output version are identical, a clone is returned.
      *
-     * @param Component\VCard $input
-     * @param int             $targetVersion
+     * @param int $targetVersion
      */
     public function convert(Component\VCard $input, $targetVersion)
     {
@@ -62,10 +61,7 @@ class VCardConverter
     /**
      * Handles conversion of a single property.
      *
-     * @param Component\VCard $input
-     * @param Component\VCard $output
-     * @param Property        $property
-     * @param int             $targetVersion
+     * @param int $targetVersion
      */
     protected function convertProperty(Component\VCard $input, Component\VCard $output, Property $property, $targetVersion)
     {
@@ -245,8 +241,7 @@ class VCardConverter
      *
      * vCard 4.0 no longer supports BINARY properties.
      *
-     * @param Component\VCard $output
-     * @param Property\Uri    $property the input property
+     * @param Property\Uri $property the input property
      * @param $parameters list of parameters that will eventually be added to
      *                    the new property
      *
@@ -299,8 +294,7 @@ class VCardConverter
      * be valid in vCard 3.0 as well, we should convert those to BINARY if
      * possible, to improve compatibility.
      *
-     * @param Component\VCard $output
-     * @param Property\Uri    $property the input property
+     * @param Property\Uri $property the input property
      *
      * @return Property\Binary|null
      */
@@ -347,9 +341,6 @@ class VCardConverter
 
     /**
      * Adds parameters to a new property for vCard 4.0.
-     *
-     * @param Property $newProperty
-     * @param array    $parameters
      */
     protected function convertParameters40(Property $newProperty, array $parameters)
     {
@@ -386,9 +377,6 @@ class VCardConverter
 
     /**
      * Adds parameters to a new property for vCard 3.0.
-     *
-     * @param Property $newProperty
-     * @param array    $parameters
      */
     protected function convertParameters30(Property $newProperty, array $parameters)
     {

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -19,8 +19,6 @@ class Writer
     /**
      * Serializes a vCard or iCalendar object.
      *
-     * @param Component $component
-     *
      * @return string
      */
     public static function write(Component $component)
@@ -31,8 +29,7 @@ class Writer
     /**
      * Serializes a jCal or jCard object.
      *
-     * @param Component $component
-     * @param int       $options
+     * @param int $options
      *
      * @return string
      */
@@ -43,8 +40,6 @@ class Writer
 
     /**
      * Serializes a xCal or xCard object.
-     *
-     * @param Component $component
      *
      * @return string
      */


### PR DESCRIPTION
- apply php-cs-fixer code style changes
- run php-cs-fixer in CI

This PR is on top of #491 

`php-cs-fixer` cleaned up a lot of PHPdoc where the parameter already had a type specified in the actual function call. I guess that is the "modern" way - specify the type in the function call and do not duplicate it in the PHPdoc.