### PR TITLE
php-cs-fixer must be at least 2.16.1 for PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "sabre/xml"    : "^2.1"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "2.16.*",
+        "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpunit/phpunit" : "^7"
     },
     "suggest" : {


### PR DESCRIPTION
might as well get this the same in all repos