### PR TITLE
Refactored fqcn strings to ::class to allow checking with phpstan

### DIFF
--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -37,15 +37,15 @@ class VCalendar extends VObject\Document
      * @var array
      */
     public static $componentMap = [
-        'VCALENDAR' => 'Sabre\\VObject\\Component\\VCalendar',
-        'VALARM' => 'Sabre\\VObject\\Component\\VAlarm',
-        'VEVENT' => 'Sabre\\VObject\\Component\\VEvent',
-        'VFREEBUSY' => 'Sabre\\VObject\\Component\\VFreeBusy',
-        'VAVAILABILITY' => 'Sabre\\VObject\\Component\\VAvailability',
-        'AVAILABLE' => 'Sabre\\VObject\\Component\\Available',
-        'VJOURNAL' => 'Sabre\\VObject\\Component\\VJournal',
-        'VTIMEZONE' => 'Sabre\\VObject\\Component\\VTimeZone',
-        'VTODO' => 'Sabre\\VObject\\Component\\VTodo',
+        'VCALENDAR' => self::class,
+        'VALARM' => VAlarm::class,
+        'VEVENT' => VEvent::class,
+        'VFREEBUSY' => VFreeBusy::class,
+        'VAVAILABILITY' => VAvailability::class,
+        'AVAILABLE' => Available::class,
+        'VJOURNAL' => VJournal::class,
+        'VTIMEZONE' => VTimeZone::class,
+        'VTODO' => VTodo::class,
     ];
 
     /**
@@ -54,21 +54,21 @@ class VCalendar extends VObject\Document
      * @var array
      */
     public static $valueMap = [
-        'BINARY' => 'Sabre\\VObject\\Property\\Binary',
-        'BOOLEAN' => 'Sabre\\VObject\\Property\\Boolean',
-        'CAL-ADDRESS' => 'Sabre\\VObject\\Property\\ICalendar\\CalAddress',
-        'DATE' => 'Sabre\\VObject\\Property\\ICalendar\\Date',
-        'DATE-TIME' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DURATION' => 'Sabre\\VObject\\Property\\ICalendar\\Duration',
-        'FLOAT' => 'Sabre\\VObject\\Property\\FloatValue',
-        'INTEGER' => 'Sabre\\VObject\\Property\\IntegerValue',
-        'PERIOD' => 'Sabre\\VObject\\Property\\ICalendar\\Period',
-        'RECUR' => 'Sabre\\VObject\\Property\\ICalendar\\Recur',
-        'TEXT' => 'Sabre\\VObject\\Property\\Text',
-        'TIME' => 'Sabre\\VObject\\Property\\Time',
-        'UNKNOWN' => 'Sabre\\VObject\\Property\\Unknown', // jCard / jCal-only.
-        'URI' => 'Sabre\\VObject\\Property\\Uri',
-        'UTC-OFFSET' => 'Sabre\\VObject\\Property\\UtcOffset',
+        'BINARY' => VObject\Property\Binary::class,
+        'BOOLEAN' => VObject\Property\Boolean::class,
+        'CAL-ADDRESS' => VObject\Property\ICalendar\CalAddress::class,
+        'DATE' => VObject\Property\ICalendar\Date::class,
+        'DATE-TIME' => VObject\Property\ICalendar\DateTime::class,
+        'DURATION' => VObject\Property\ICalendar\Duration::class,
+        'FLOAT' => VObject\Property\FloatValue::class,
+        'INTEGER' => VObject\Property\IntegerValue::class,
+        'PERIOD' => VObject\Property\ICalendar\Period::class,
+        'RECUR' => VObject\Property\ICalendar\Recur::class,
+        'TEXT' => VObject\Property\Text::class,
+        'TIME' => VObject\Property\Time::class,
+        'UNKNOWN' => VObject\Property\Unknown::class, // jCard / jCal-only.
+        'URI' => VObject\Property\Uri::class,
+        'UTC-OFFSET' => VObject\Property\UtcOffset::class,
     ];
 
     /**
@@ -78,78 +78,78 @@ class VCalendar extends VObject\Document
      */
     public static $propertyMap = [
         // Calendar properties
-        'CALSCALE' => 'Sabre\\VObject\\Property\\FlatText',
-        'METHOD' => 'Sabre\\VObject\\Property\\FlatText',
-        'PRODID' => 'Sabre\\VObject\\Property\\FlatText',
-        'VERSION' => 'Sabre\\VObject\\Property\\FlatText',
+        'CALSCALE' => VObject\Property\FlatText::class,
+        'METHOD' => VObject\Property\FlatText::class,
+        'PRODID' => VObject\Property\FlatText::class,
+        'VERSION' => VObject\Property\FlatText::class,
 
         // Component properties
-        'ATTACH' => 'Sabre\\VObject\\Property\\Uri',
-        'CATEGORIES' => 'Sabre\\VObject\\Property\\Text',
-        'CLASS' => 'Sabre\\VObject\\Property\\FlatText',
-        'COMMENT' => 'Sabre\\VObject\\Property\\FlatText',
-        'DESCRIPTION' => 'Sabre\\VObject\\Property\\FlatText',
-        'GEO' => 'Sabre\\VObject\\Property\\FloatValue',
-        'LOCATION' => 'Sabre\\VObject\\Property\\FlatText',
-        'PERCENT-COMPLETE' => 'Sabre\\VObject\\Property\\IntegerValue',
-        'PRIORITY' => 'Sabre\\VObject\\Property\\IntegerValue',
-        'RESOURCES' => 'Sabre\\VObject\\Property\\Text',
-        'STATUS' => 'Sabre\\VObject\\Property\\FlatText',
-        'SUMMARY' => 'Sabre\\VObject\\Property\\FlatText',
+        'ATTACH' => VObject\Property\Uri::class,
+        'CATEGORIES' => VObject\Property\Text::class,
+        'CLASS' => VObject\Property\FlatText::class,
+        'COMMENT' => VObject\Property\FlatText::class,
+        'DESCRIPTION' => VObject\Property\FlatText::class,
+        'GEO' => VObject\Property\FloatValue::class,
+        'LOCATION' => VObject\Property\FlatText::class,
+        'PERCENT-COMPLETE' => VObject\Property\IntegerValue::class,
+        'PRIORITY' => VObject\Property\IntegerValue::class,
+        'RESOURCES' => VObject\Property\Text::class,
+        'STATUS' => VObject\Property\FlatText::class,
+        'SUMMARY' => VObject\Property\FlatText::class,
 
         // Date and Time Component Properties
-        'COMPLETED' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DTEND' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DUE' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DTSTART' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DURATION' => 'Sabre\\VObject\\Property\\ICalendar\\Duration',
-        'FREEBUSY' => 'Sabre\\VObject\\Property\\ICalendar\\Period',
-        'TRANSP' => 'Sabre\\VObject\\Property\\FlatText',
+        'COMPLETED' => VObject\Property\ICalendar\DateTime::class,
+        'DTEND' => VObject\Property\ICalendar\DateTime::class,
+        'DUE' => VObject\Property\ICalendar\DateTime::class,
+        'DTSTART' => VObject\Property\ICalendar\DateTime::class,
+        'DURATION' => VObject\Property\ICalendar\Duration::class,
+        'FREEBUSY' => VObject\Property\ICalendar\Period::class,
+        'TRANSP' => VObject\Property\FlatText::class,
 
         // Time Zone Component Properties
-        'TZID' => 'Sabre\\VObject\\Property\\FlatText',
-        'TZNAME' => 'Sabre\\VObject\\Property\\FlatText',
-        'TZOFFSETFROM' => 'Sabre\\VObject\\Property\\UtcOffset',
-        'TZOFFSETTO' => 'Sabre\\VObject\\Property\\UtcOffset',
-        'TZURL' => 'Sabre\\VObject\\Property\\Uri',
+        'TZID' => VObject\Property\FlatText::class,
+        'TZNAME' => VObject\Property\FlatText::class,
+        'TZOFFSETFROM' => VObject\Property\UtcOffset::class,
+        'TZOFFSETTO' => VObject\Property\UtcOffset::class,
+        'TZURL' => VObject\Property\Uri::class,
 
         // Relationship Component Properties
-        'ATTENDEE' => 'Sabre\\VObject\\Property\\ICalendar\\CalAddress',
-        'CONTACT' => 'Sabre\\VObject\\Property\\FlatText',
-        'ORGANIZER' => 'Sabre\\VObject\\Property\\ICalendar\\CalAddress',
-        'RECURRENCE-ID' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'RELATED-TO' => 'Sabre\\VObject\\Property\\FlatText',
-        'URL' => 'Sabre\\VObject\\Property\\Uri',
-        'UID' => 'Sabre\\VObject\\Property\\FlatText',
+        'ATTENDEE' => VObject\Property\ICalendar\CalAddress::class,
+        'CONTACT' => VObject\Property\FlatText::class,
+        'ORGANIZER' => VObject\Property\ICalendar\CalAddress::class,
+        'RECURRENCE-ID' => VObject\Property\ICalendar\DateTime::class,
+        'RELATED-TO' => VObject\Property\FlatText::class,
+        'URL' => VObject\Property\Uri::class,
+        'UID' => VObject\Property\FlatText::class,
 
         // Recurrence Component Properties
-        'EXDATE' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'RDATE' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'RRULE' => 'Sabre\\VObject\\Property\\ICalendar\\Recur',
-        'EXRULE' => 'Sabre\\VObject\\Property\\ICalendar\\Recur', // Deprecated since rfc5545
+        'EXDATE' => VObject\Property\ICalendar\DateTime::class,
+        'RDATE' => VObject\Property\ICalendar\DateTime::class,
+        'RRULE' => VObject\Property\ICalendar\Recur::class,
+        'EXRULE' => VObject\Property\ICalendar\Recur::class, // Deprecated since rfc5545
 
         // Alarm Component Properties
-        'ACTION' => 'Sabre\\VObject\\Property\\FlatText',
-        'REPEAT' => 'Sabre\\VObject\\Property\\IntegerValue',
-        'TRIGGER' => 'Sabre\\VObject\\Property\\ICalendar\\Duration',
+        'ACTION' => VObject\Property\FlatText::class,
+        'REPEAT' => VObject\Property\IntegerValue::class,
+        'TRIGGER' => VObject\Property\ICalendar\Duration::class,
 
         // Change Management Component Properties
-        'CREATED' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'DTSTAMP' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'LAST-MODIFIED' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'SEQUENCE' => 'Sabre\\VObject\\Property\\IntegerValue',
+        'CREATED' => VObject\Property\ICalendar\DateTime::class,
+        'DTSTAMP' => VObject\Property\ICalendar\DateTime::class,
+        'LAST-MODIFIED' => VObject\Property\ICalendar\DateTime::class,
+        'SEQUENCE' => VObject\Property\IntegerValue::class,
 
         // Request Status
-        'REQUEST-STATUS' => 'Sabre\\VObject\\Property\\Text',
+        'REQUEST-STATUS' => VObject\Property\Text::class,
 
         // Additions from draft-daboo-valarm-extensions-04
-        'ALARM-AGENT' => 'Sabre\\VObject\\Property\\Text',
-        'ACKNOWLEDGED' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'PROXIMITY' => 'Sabre\\VObject\\Property\\Text',
-        'DEFAULT-ALARM' => 'Sabre\\VObject\\Property\\Boolean',
+        'ALARM-AGENT' => VObject\Property\Text::class,
+        'ACKNOWLEDGED' => VObject\Property\ICalendar\DateTime::class,
+        'PROXIMITY' => VObject\Property\Text::class,
+        'DEFAULT-ALARM' => VObject\Property\Boolean::class,
 
         // Additions from draft-daboo-calendar-availability-05
-        'BUSYTYPE' => 'Sabre\\VObject\\Property\\Text',
+        'BUSYTYPE' => VObject\Property\Text::class,
     ];
 
     /**

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -39,7 +39,7 @@ class VCard extends VObject\Document
      * @var array
      */
     public static $componentMap = [
-        'VCARD' => 'Sabre\\VObject\\Component\\VCard',
+        'VCARD' => VCard::class,
     ];
 
     /**
@@ -48,23 +48,23 @@ class VCard extends VObject\Document
      * @var array
      */
     public static $valueMap = [
-        'BINARY' => 'Sabre\\VObject\\Property\\Binary',
-        'BOOLEAN' => 'Sabre\\VObject\\Property\\Boolean',
-        'CONTENT-ID' => 'Sabre\\VObject\\Property\\FlatText',   // vCard 2.1 only
-        'DATE' => 'Sabre\\VObject\\Property\\VCard\\Date',
-        'DATE-TIME' => 'Sabre\\VObject\\Property\\VCard\\DateTime',
-        'DATE-AND-OR-TIME' => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime', // vCard only
-        'FLOAT' => 'Sabre\\VObject\\Property\\FloatValue',
-        'INTEGER' => 'Sabre\\VObject\\Property\\IntegerValue',
-        'LANGUAGE-TAG' => 'Sabre\\VObject\\Property\\VCard\\LanguageTag',
-        'PHONE-NUMBER' => 'Sabre\\VObject\\Property\\VCard\\PhoneNumber', // vCard 3.0 only
-        'TIMESTAMP' => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
-        'TEXT' => 'Sabre\\VObject\\Property\\Text',
-        'TIME' => 'Sabre\\VObject\\Property\\Time',
-        'UNKNOWN' => 'Sabre\\VObject\\Property\\Unknown', // jCard / jCal-only.
-        'URI' => 'Sabre\\VObject\\Property\\Uri',
-        'URL' => 'Sabre\\VObject\\Property\\Uri', // vCard 2.1 only
-        'UTC-OFFSET' => 'Sabre\\VObject\\Property\\UtcOffset',
+        'BINARY' => VObject\Property\Binary::class,
+        'BOOLEAN' => VObject\Property\Boolean::class,
+        'CONTENT-ID' => VObject\Property\FlatText::class,   // vCard 2.1 only
+        'DATE' => VObject\Property\VCard\Date::class,
+        'DATE-TIME' => VObject\Property\VCard\DateTime::class,
+        'DATE-AND-OR-TIME' => VObject\Property\VCard\DateAndOrTime::class, // vCard only
+        'FLOAT' => VObject\Property\FloatValue::class,
+        'INTEGER' => VObject\Property\IntegerValue::class,
+        'LANGUAGE-TAG' => VObject\Property\VCard\LanguageTag::class,
+        'PHONE-NUMBER' => VObject\Property\VCard\PhoneNumber::class, // vCard 3.0 only
+        'TIMESTAMP' => VObject\Property\VCard\TimeStamp::class,
+        'TEXT' => VObject\Property\Text::class,
+        'TIME' => VObject\Property\Time::class,
+        'UNKNOWN' => VObject\Property\Unknown::class, // jCard / jCal-only.
+        'URI' => VObject\Property\Uri::class,
+        'URL' => VObject\Property\Uri::class, // vCard 2.1 only
+        'UTC-OFFSET' => VObject\Property\UtcOffset::class,
     ];
 
     /**
@@ -74,68 +74,68 @@ class VCard extends VObject\Document
      */
     public static $propertyMap = [
         // vCard 2.1 properties and up
-        'N' => 'Sabre\\VObject\\Property\\Text',
-        'FN' => 'Sabre\\VObject\\Property\\FlatText',
-        'PHOTO' => 'Sabre\\VObject\\Property\\Binary',
-        'BDAY' => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
-        'ADR' => 'Sabre\\VObject\\Property\\Text',
-        'LABEL' => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'TEL' => 'Sabre\\VObject\\Property\\FlatText',
-        'EMAIL' => 'Sabre\\VObject\\Property\\FlatText',
-        'MAILER' => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'GEO' => 'Sabre\\VObject\\Property\\FlatText',
-        'TITLE' => 'Sabre\\VObject\\Property\\FlatText',
-        'ROLE' => 'Sabre\\VObject\\Property\\FlatText',
-        'LOGO' => 'Sabre\\VObject\\Property\\Binary',
+        'N' => VObject\Property\Text::class,
+        'FN' => VObject\Property\FlatText::class,
+        'PHOTO' => VObject\Property\Binary::class,
+        'BDAY' => VObject\Property\VCard\DateAndOrTime::class,
+        'ADR' => VObject\Property\Text::class,
+        'LABEL' => VObject\Property\FlatText::class, // Removed in vCard 4.0
+        'TEL' => VObject\Property\FlatText::class,
+        'EMAIL' => VObject\Property\FlatText::class,
+        'MAILER' => VObject\Property\FlatText::class, // Removed in vCard 4.0
+        'GEO' => VObject\Property\FlatText::class,
+        'TITLE' => VObject\Property\FlatText::class,
+        'ROLE' => VObject\Property\FlatText::class,
+        'LOGO' => VObject\Property\Binary::class,
         // 'AGENT'   => 'Sabre\\VObject\\Property\\',      // Todo: is an embedded vCard. Probably rare, so
                                  // not supported at the moment
-        'ORG' => 'Sabre\\VObject\\Property\\Text',
-        'NOTE' => 'Sabre\\VObject\\Property\\FlatText',
-        'REV' => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
-        'SOUND' => 'Sabre\\VObject\\Property\\FlatText',
-        'URL' => 'Sabre\\VObject\\Property\\Uri',
-        'UID' => 'Sabre\\VObject\\Property\\FlatText',
-        'VERSION' => 'Sabre\\VObject\\Property\\FlatText',
-        'KEY' => 'Sabre\\VObject\\Property\\FlatText',
-        'TZ' => 'Sabre\\VObject\\Property\\Text',
+        'ORG' => VObject\Property\Text::class,
+        'NOTE' => VObject\Property\FlatText::class,
+        'REV' => VObject\Property\VCard\TimeStamp::class,
+        'SOUND' => VObject\Property\FlatText::class,
+        'URL' => VObject\Property\Uri::class,
+        'UID' => VObject\Property\FlatText::class,
+        'VERSION' => VObject\Property\FlatText::class,
+        'KEY' => VObject\Property\FlatText::class,
+        'TZ' => VObject\Property\Text::class,
 
         // vCard 3.0 properties
-        'CATEGORIES' => 'Sabre\\VObject\\Property\\Text',
-        'SORT-STRING' => 'Sabre\\VObject\\Property\\FlatText',
-        'PRODID' => 'Sabre\\VObject\\Property\\FlatText',
-        'NICKNAME' => 'Sabre\\VObject\\Property\\Text',
-        'CLASS' => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
+        'CATEGORIES' => VObject\Property\Text::class,
+        'SORT-STRING' => VObject\Property\FlatText::class,
+        'PRODID' => VObject\Property\FlatText::class,
+        'NICKNAME' => VObject\Property\Text::class,
+        'CLASS' => VObject\Property\FlatText::class, // Removed in vCard 4.0
 
         // rfc2739 properties
-        'FBURL' => 'Sabre\\VObject\\Property\\Uri',
-        'CAPURI' => 'Sabre\\VObject\\Property\\Uri',
-        'CALURI' => 'Sabre\\VObject\\Property\\Uri',
-        'CALADRURI' => 'Sabre\\VObject\\Property\\Uri',
+        'FBURL' => VObject\Property\Uri::class,
+        'CAPURI' => VObject\Property\Uri::class,
+        'CALURI' => VObject\Property\Uri::class,
+        'CALADRURI' => VObject\Property\Uri::class,
 
         // rfc4770 properties
-        'IMPP' => 'Sabre\\VObject\\Property\\Uri',
+        'IMPP' => VObject\Property\Uri::class,
 
         // vCard 4.0 properties
-        'SOURCE' => 'Sabre\\VObject\\Property\\Uri',
-        'XML' => 'Sabre\\VObject\\Property\\FlatText',
-        'ANNIVERSARY' => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
-        'CLIENTPIDMAP' => 'Sabre\\VObject\\Property\\Text',
-        'LANG' => 'Sabre\\VObject\\Property\\VCard\\LanguageTag',
-        'GENDER' => 'Sabre\\VObject\\Property\\Text',
-        'KIND' => 'Sabre\\VObject\\Property\\FlatText',
-        'MEMBER' => 'Sabre\\VObject\\Property\\Uri',
-        'RELATED' => 'Sabre\\VObject\\Property\\Uri',
+        'SOURCE' => VObject\Property\Uri::class,
+        'XML' => VObject\Property\FlatText::class,
+        'ANNIVERSARY' => VObject\Property\VCard\DateAndOrTime::class,
+        'CLIENTPIDMAP' => VObject\Property\Text::class,
+        'LANG' => VObject\Property\VCard\LanguageTag::class,
+        'GENDER' => VObject\Property\Text::class,
+        'KIND' => VObject\Property\FlatText::class,
+        'MEMBER' => VObject\Property\Uri::class,
+        'RELATED' => VObject\Property\Uri::class,
 
         // rfc6474 properties
-        'BIRTHPLACE' => 'Sabre\\VObject\\Property\\FlatText',
-        'DEATHPLACE' => 'Sabre\\VObject\\Property\\FlatText',
-        'DEATHDATE' => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
+        'BIRTHPLACE' => VObject\Property\FlatText::class,
+        'DEATHPLACE' => VObject\Property\FlatText::class,
+        'DEATHDATE' => VObject\Property\VCard\DateAndOrTime::class,
 
         // rfc6715 properties
-        'EXPERTISE' => 'Sabre\\VObject\\Property\\FlatText',
-        'HOBBY' => 'Sabre\\VObject\\Property\\FlatText',
-        'INTEREST' => 'Sabre\\VObject\\Property\\FlatText',
-        'ORG-DIRECTORY' => 'Sabre\\VObject\\Property\\FlatText',
+        'EXPERTISE' => VObject\Property\FlatText::class,
+        'HOBBY' => VObject\Property\FlatText::class,
+        'INTEREST' => VObject\Property\FlatText::class,
+        'ORG-DIRECTORY' => VObject\Property\FlatText::class,
     ];
 
     /**
@@ -526,8 +526,8 @@ class VCard extends VObject\Document
         $className = parent::getClassNameForPropertyName($propertyName);
 
         // In vCard 4, BINARY no longer exists, and we need URI instead.
-        if ('Sabre\\VObject\\Property\\Binary' == $className && self::VCARD40 === $this->getDocumentType()) {
-            return 'Sabre\\VObject\\Property\\Uri';
+        if (VObject\Property\Binary::class == $className && self::VCARD40 === $this->getDocumentType()) {
+            return VObject\Property\Uri::class;
         }
 
         return $className;

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -160,7 +160,7 @@ abstract class Document extends Component
     public function createComponent($name, array $children = null, $defaults = true)
     {
         $name = strtoupper($name);
-        $class = 'Sabre\\VObject\\Component';
+        $class = Component::class;
 
         if (isset(static::$componentMap[$name])) {
             $class = static::$componentMap[$name];
@@ -258,7 +258,7 @@ abstract class Document extends Component
         if (isset(static::$propertyMap[$propertyName])) {
             return static::$propertyMap[$propertyName];
         } else {
-            return 'Sabre\\VObject\\Property\\Unknown';
+            return Property\Unknown::class;
         }
     }
 }

--- a/lib/Parser/Json.php
+++ b/lib/Parser/Json.php
@@ -7,6 +7,8 @@ use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Document;
 use Sabre\VObject\EofException;
 use Sabre\VObject\ParseException;
+use Sabre\VObject\Property\FlatText;
+use Sabre\VObject\Property\Text;
 
 /**
  * Json Parser.
@@ -156,8 +158,8 @@ class Json extends Parser
         // represents TEXT values. We have to normalize these here. In the
         // future we can get rid of FlatText once we're allowed to break BC
         // again.
-        if ('Sabre\VObject\Property\FlatText' === $defaultPropertyClass) {
-            $defaultPropertyClass = 'Sabre\VObject\Property\Text';
+        if (FlatText::class === $defaultPropertyClass) {
+            $defaultPropertyClass = Text::class;
         }
 
         // If the value type we received (e.g.: TEXT) was not the default value

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -351,9 +351,9 @@ class XML extends Parser
         if (is_string($input)) {
             $reader = new SabreXml\Reader();
             $reader->elementMap['{'.self::XCAL_NAMESPACE.'}period']
-                = 'Sabre\VObject\Parser\XML\Element\KeyValue';
+                = XML\Element\KeyValue::class;
             $reader->elementMap['{'.self::XCAL_NAMESPACE.'}recur']
-                = 'Sabre\VObject\Parser\XML\Element\KeyValue';
+                = XML\Element\KeyValue::class;
             $reader->xml($input);
             $input = $reader->parse();
         }

--- a/tests/VObject/Component/AvailableTest.php
+++ b/tests/VObject/Component/AvailableTest.php
@@ -22,7 +22,7 @@ END:AVAILABLE
 END:VCALENDAR
 VCAL;
         $document = Reader::read($vcal);
-        $this->assertInstanceOf(__NAMESPACE__.'\Available', $document->AVAILABLE);
+        $this->assertInstanceOf(Available::class, $document->AVAILABLE);
     }
 
     public function testGetEffectiveStartEnd()

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -24,7 +24,7 @@ END:VCALENDAR
 VCAL;
         $document = Reader::read($vcal);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\VAvailability', $document->VAVAILABILITY);
+        $this->assertInstanceOf(VAvailability::class, $document->VAVAILABILITY);
     }
 
     public function testGetEffectiveStartEnd()
@@ -236,7 +236,7 @@ END:VCALENDAR
 VCAL;
         $document = Reader::read($vcal);
 
-        $this->assertInstanceOf(__NAMESPACE__, $document->VAVAILABILITY->AVAILABLE);
+        $this->assertInstanceOf(Available::class, $document->VAVAILABILITY->AVAILABLE);
     }
 
     public function testRFCxxxSection3_1_availableprop_required()

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -21,7 +21,7 @@ class ComponentTest extends TestCase
         $count = 0;
         foreach ($comp->children() as $key => $subcomponent) {
             ++$count;
-            $this->assertInstanceOf('Sabre\\VObject\\Component', $subcomponent);
+            $this->assertInstanceOf(Component::class, $subcomponent);
 
             if (2 === $count) {
                 $this->assertEquals(1, $key);
@@ -41,7 +41,7 @@ class ComponentTest extends TestCase
         $comp->add($sub);
 
         $event = $comp->vevent;
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $event);
+        $this->assertInstanceOf(Component::class, $event);
         $this->assertEquals('VEVENT', $event->name);
 
         $this->assertNull($comp->vjournal);
@@ -92,7 +92,7 @@ class ComponentTest extends TestCase
         $comp = new VCalendar();
         $comp->myProp = 'myValue';
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $comp->MYPROP);
+        $this->assertInstanceOf(Property::class, $comp->MYPROP);
         $this->assertEquals('myValue', (string) $comp->MYPROP);
     }
 
@@ -103,7 +103,7 @@ class ComponentTest extends TestCase
         $comp->myProp = 'myValue';
 
         $this->assertEquals(1, count($comp->children()));
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $comp->MYPROP);
+        $this->assertInstanceOf(Property::class, $comp->MYPROP);
         $this->assertEquals('myValue', (string) $comp->MYPROP);
     }
 
@@ -112,7 +112,7 @@ class ComponentTest extends TestCase
         $comp = new VCalendar();
         $comp->ORG = ['Acme Inc', 'Section 9'];
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $comp->ORG);
+        $this->assertInstanceOf(Property::class, $comp->ORG);
         $this->assertEquals(['Acme Inc', 'Section 9'], $comp->ORG->getParts());
     }
 
@@ -216,7 +216,7 @@ class ComponentTest extends TestCase
 
         $bla = $comp->children()[0];
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $bla);
+        $this->assertInstanceOf(Property::class, $bla);
         $this->assertEquals('MYPROP', $bla->name);
         $this->assertEquals('value', (string) $bla);
 

--- a/tests/VObject/DocumentTest.php
+++ b/tests/VObject/DocumentTest.php
@@ -24,11 +24,11 @@ class DocumentTest extends TestCase
 
         $event = $vcal->createComponent('VEVENT');
 
-        $this->assertInstanceOf('Sabre\VObject\Component\VEvent', $event);
+        $this->assertInstanceOf(Component\VEvent::class, $event);
         $vcal->add($event);
 
         $prop = $vcal->createProperty('X-PROP', '1234256', ['X-PARAM' => '3']);
-        $this->assertInstanceOf('Sabre\VObject\Property', $prop);
+        $this->assertInstanceOf(Property::class, $prop);
 
         $event->add($prop);
 
@@ -46,16 +46,16 @@ class DocumentTest extends TestCase
         $vcal = new Component\VCalendar([], false);
 
         $event = $vcal->create('VEVENT');
-        $this->assertInstanceOf('Sabre\VObject\Component\VEvent', $event);
+        $this->assertInstanceOf(Component\VEvent::class, $event);
 
         $prop = $vcal->create('CALSCALE');
-        $this->assertInstanceOf('Sabre\VObject\Property\Text', $prop);
+        $this->assertInstanceOf(Property\Text::class, $prop);
     }
 
     public function testGetClassNameForPropertyValue()
     {
         $vcal = new Component\VCalendar([], false);
-        $this->assertEquals('Sabre\\VObject\\Property\\Text', $vcal->getClassNameForPropertyValue('TEXT'));
+        $this->assertEquals(Property\Text::class, $vcal->getClassNameForPropertyValue('TEXT'));
         $this->assertNull($vcal->getClassNameForPropertyValue('FOO'));
     }
 
@@ -64,7 +64,7 @@ class DocumentTest extends TestCase
         $vcal = new Component\VCalendar([], false);
         $event = $vcal->createComponent('VEVENT');
 
-        $this->assertInstanceOf('Sabre\VObject\Component\VEvent', $event);
+        $this->assertInstanceOf(Component\VEvent::class, $event);
         $vcal->add($event);
 
         $prop = $vcal->createProperty('X-PROP', '1234256', ['X-PARAM' => '3']);

--- a/tests/VObject/ElementListTest.php
+++ b/tests/VObject/ElementListTest.php
@@ -22,7 +22,7 @@ class ElementListTest extends TestCase
         $count = 0;
         foreach ($elemList as $key => $subcomponent) {
             ++$count;
-            $this->assertInstanceOf('Sabre\\VObject\\Component', $subcomponent);
+            $this->assertInstanceOf(Component::class, $subcomponent);
 
             if (3 === $count) {
                 $this->assertEquals(2, $key);

--- a/tests/VObject/EmptyParameterTest.php
+++ b/tests/VObject/EmptyParameterTest.php
@@ -20,7 +20,7 @@ VCF;
 
         $vcard = Reader::read($input);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCard', $vcard);
+        $this->assertInstanceOf(Component\VCard::class, $vcard);
         $vcard = $vcard->convert(\Sabre\VObject\Document::VCARD30);
         $vcard = $vcard->serialize();
 

--- a/tests/VObject/ICalendar/AttachParseTest.php
+++ b/tests/VObject/ICalendar/AttachParseTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\VObject\ICalendar;
 
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Property\Uri;
 use Sabre\VObject\Reader;
 
 class AttachParseTest extends TestCase
@@ -23,7 +24,7 @@ ICS;
         $vcal = Reader::read($vcal);
         $prop = $vcal->VEVENT->ATTACH;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property\\URI', $prop);
+        $this->assertInstanceOf(Uri::class, $prop);
         $this->assertEquals('ftp://example.com/pub/reports/r-960812.ps', $prop->getValue());
     }
 }

--- a/tests/VObject/Issue36WorkAroundTest.php
+++ b/tests/VObject/Issue36WorkAroundTest.php
@@ -34,6 +34,6 @@ ICS;
 
         // If this does not throw an exception, it's all good.
         $it = new Recur\EventIterator($obj, '1833bd44-188b-405c-9f85-1a12105318aa');
-        $this->assertInstanceOf('Sabre\\VObject\\Recur\\EventIterator', $it);
+        $this->assertInstanceOf(Recur\EventIterator::class, $it);
     }
 }

--- a/tests/VObject/Issue64Test.php
+++ b/tests/VObject/Issue64Test.php
@@ -14,6 +14,6 @@ class Issue64Test extends TestCase
 
         $converted = Reader::read($vcard);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCard', $converted);
+        $this->assertInstanceOf(Component\VCard::class, $converted);
     }
 }

--- a/tests/VObject/Issue96Test.php
+++ b/tests/VObject/Issue96Test.php
@@ -18,7 +18,7 @@ END:VCARD
 VCF;
 
         $vcard = Reader::read($input, Reader::OPTION_FORGIVING);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCard', $vcard);
+        $this->assertInstanceOf(Component\VCard::class, $vcard);
         $this->assertEquals('http://www.example.org', $vcard->URL->getValue());
     }
 }

--- a/tests/VObject/Parser/QuotedPrintableTest.php
+++ b/tests/VObject/Parser/QuotedPrintableTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\VObject\Parser;
 
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component;
 use Sabre\VObject\Reader;
 
 class QuotedPrintableTest extends TestCase
@@ -13,7 +14,7 @@ class QuotedPrintableTest extends TestCase
 
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCARD', $result->name);
         $this->assertEquals(1, count($result->children()));
         $this->assertEquals('Aachen', $this->getPropertyValue($result->LABEL));
@@ -24,7 +25,7 @@ class QuotedPrintableTest extends TestCase
         $data = "BEGIN:VCARD\r\nLABEL;ENCODING=QUOTED-PRINTABLE:Aa=\r\n ch=\r\n en\r\nEND:VCARD";
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCARD', $result->name);
         $this->assertEquals(1, count($result->children()));
         $this->assertEquals('Aachen', $this->getPropertyValue($result->LABEL));
@@ -35,7 +36,7 @@ class QuotedPrintableTest extends TestCase
         $data = "BEGIN:VCARD\r\nLABEL;ENCODING=QUOTED-PRINTABLE:Aachen=0D=0A=\r\n Germany\r\nEND:VCARD";
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCARD', $result->name);
         $this->assertEquals(1, count($result->children()));
         $this->assertEquals("Aachen\r\nGermany", $this->getPropertyValue($result->LABEL));
@@ -46,7 +47,7 @@ class QuotedPrintableTest extends TestCase
         $data = "BEGIN:VCARD\r\nLABEL;ENCODING=QUOTED-PRINTABLE:Aachen=0D=0A=\r\nDeutschland:okay\r\nEND:VCARD";
         $result = Reader::read($data, Reader::OPTION_FORGIVING);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCARD', $result->name);
         $this->assertEquals(1, count($result->children()));
         $this->assertEquals("Aachen\r\nDeutschland:okay", $this->getPropertyValue($result->LABEL));

--- a/tests/VObject/Property/FloatTest.php
+++ b/tests/VObject/Property/FloatTest.php
@@ -14,7 +14,7 @@ class FloatTest extends TestCase
 
         $result = $mimeDir->parse($input);
 
-        $this->assertInstanceOf('Sabre\VObject\Property\FloatValue', $result->{'X-FLOAT'});
+        $this->assertInstanceOf(FloatValue::class, $result->{'X-FLOAT'});
 
         $this->assertEquals([
             0.234,

--- a/tests/VObject/Property/ICalendar/RecurTest.php
+++ b/tests/VObject/Property/ICalendar/RecurTest.php
@@ -16,7 +16,7 @@ class RecurTest extends TestCase
         $vcal = new VCalendar();
         $recur = $vcal->add('RRULE', 'FREQ=Daily');
 
-        $this->assertInstanceOf('Sabre\VObject\Property\ICalendar\Recur', $recur);
+        $this->assertInstanceOf(Recur::class, $recur);
 
         $this->assertEquals(['FREQ' => 'DAILY'], $recur->getParts());
         $recur->setParts(['freq' => 'MONTHLY']);

--- a/tests/VObject/Property/VCard/LanguageTagTest.php
+++ b/tests/VObject/Property/VCard/LanguageTagTest.php
@@ -14,7 +14,7 @@ class LanguageTagTest extends TestCase
 
         $result = $mimeDir->parse($input);
 
-        $this->assertInstanceOf('Sabre\VObject\Property\VCard\LanguageTag', $result->LANG);
+        $this->assertInstanceOf(LanguageTag::class, $result->LANG);
 
         $this->assertEquals('nl', $result->LANG->getValue());
 
@@ -31,7 +31,7 @@ class LanguageTagTest extends TestCase
 
         $result = $mimeDir->parse($input);
 
-        $this->assertInstanceOf('Sabre\VObject\Property\VCard\LanguageTag', $result->LANG);
+        $this->assertInstanceOf(LanguageTag::class, $result->LANG);
         // This replicates what the vcard converter does and triggered a bug in
         // the past.
         $result->LANG->setValue(['de']);

--- a/tests/VObject/Property/VCard/PhoneNumberTest.php
+++ b/tests/VObject/Property/VCard/PhoneNumberTest.php
@@ -12,7 +12,7 @@ class PhoneNumberTest extends TestCase
         $input = "BEGIN:VCARD\r\nVERSION:3.0\r\nTEL;TYPE=HOME;VALUE=PHONE-NUMBER:+1234\r\nEND:VCARD\r\n";
 
         $vCard = VObject\Reader::read($input);
-        $this->assertInstanceOf('Sabre\VObject\Property\VCard\PhoneNumber', $vCard->TEL);
+        $this->assertInstanceOf(PhoneNumber::class, $vCard->TEL);
         $this->assertEquals('PHONE-NUMBER', $vCard->TEL->getValueType());
         $this->assertEquals($input, $vCard->serialize());
     }

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -62,7 +62,7 @@ class PropertyTest extends TestCase
         $property = $cal->createProperty('propname', 'propvalue');
         $property['paramname'] = 'paramvalue';
 
-        $this->assertInstanceOf('Sabre\\VObject\\Parameter', $property['paramname']);
+        $this->assertInstanceOf(Parameter::class, $property['paramname']);
     }
 
     public function testParameterNotExists()
@@ -81,7 +81,7 @@ class PropertyTest extends TestCase
         $property['paramname'] = 'paramvalue';
         $property->add('paramname', 'paramvalue');
 
-        $this->assertInstanceOf('Sabre\\VObject\\Parameter', $property['paramname']);
+        $this->assertInstanceOf(Parameter::class, $property['paramname']);
         $this->assertEquals(2, count($property['paramname']->getParts()));
     }
 
@@ -92,7 +92,7 @@ class PropertyTest extends TestCase
         $property['paramname'] = 'paramvalue';
 
         $this->assertEquals(1, count($property->parameters()));
-        $this->assertInstanceOf('Sabre\\VObject\\Parameter', $property->parameters['PARAMNAME']);
+        $this->assertInstanceOf(Parameter::class, $property->parameters['PARAMNAME']);
         $this->assertEquals('PARAMNAME', $property->parameters['PARAMNAME']->name);
         $this->assertEquals('paramvalue', $property->parameters['PARAMNAME']->getValue());
     }

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -12,7 +12,7 @@ class ReaderTest extends TestCase
 
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -27,7 +27,7 @@ class ReaderTest extends TestCase
 
         $result = Reader::read($stream);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -38,7 +38,7 @@ class ReaderTest extends TestCase
 
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -49,7 +49,7 @@ class ReaderTest extends TestCase
 
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -76,7 +76,7 @@ class ReaderTest extends TestCase
         $result = Reader::read($data);
 
         $result = $result->SUMMARY;
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('SUMMARY', $result->name);
         $this->assertEquals('propValue', $result->getValue());
     }
@@ -87,7 +87,7 @@ class ReaderTest extends TestCase
         $result = Reader::read($data);
 
         $result = $result->SUMMARY;
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('SUMMARY', $result->name);
         $this->assertEquals("Line1\nLine2\nLine3\\Not the 4th line!", $result->getValue());
     }
@@ -98,7 +98,7 @@ class ReaderTest extends TestCase
         $result = Reader::read($data);
 
         $result = $result->DTSTART;
-        $this->assertInstanceOf('Sabre\\VObject\\Property\\ICalendar\\DateTime', $result);
+        $this->assertInstanceOf(Property\ICalendar\DateTime::class, $result);
         $this->assertEquals('DTSTART', $result->name);
         $this->assertEquals('20110529', $result->getValue());
     }
@@ -109,7 +109,7 @@ class ReaderTest extends TestCase
         $result = Reader::read($data);
 
         $result = $result->DTSTART;
-        $this->assertInstanceOf('Sabre\\VObject\\Property\\ICalendar\\DateTime', $result);
+        $this->assertInstanceOf(Property\ICalendar\DateTime::class, $result);
         $this->assertEquals('DTSTART', $result->name);
         $this->assertEquals('20110529', $result->getValue());
     }
@@ -131,10 +131,10 @@ class ReaderTest extends TestCase
 
         $result = Reader::read(implode("\r\n", $data));
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(1, count($result->children()));
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result->children()[0]);
+        $this->assertInstanceOf(Property::class, $result->children()[0]);
         $this->assertEquals('PROPNAME', $result->children()[0]->name);
         $this->assertEquals('propValue', $result->children()[0]->getValue());
     }
@@ -152,13 +152,13 @@ class ReaderTest extends TestCase
 
         $result = Reader::read(implode("\r\n", $data));
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(1, count($result->children()));
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result->children()[0]);
+        $this->assertInstanceOf(Component::class, $result->children()[0]);
         $this->assertEquals('VTIMEZONE', $result->children()[0]->name);
         $this->assertEquals(1, count($result->children()[0]->children()));
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result->children()[0]->children()[0]);
+        $this->assertInstanceOf(Component::class, $result->children()[0]->children()[0]);
         $this->assertEquals('DAYLIGHT', $result->children()[0]->children()[0]->name);
     }
 
@@ -169,7 +169,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -184,7 +184,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -200,7 +200,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -216,7 +216,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -232,7 +232,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue:anotherrandomstring', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -247,7 +247,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(2, count($result->parameters()));
@@ -264,7 +264,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -279,7 +279,7 @@ class ReaderTest extends TestCase
 
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
 
@@ -294,7 +294,7 @@ class ReaderTest extends TestCase
         $result = Reader::read($data);
         $result = $result->PROPNAME;
 
-        $this->assertInstanceOf('Sabre\\VObject\\Property', $result);
+        $this->assertInstanceOf(Property::class, $result);
         $this->assertEquals('PROPNAME', $result->name);
         $this->assertEquals('propValue', $result->getValue());
         $this->assertEquals(1, count($result->parameters()));
@@ -408,7 +408,7 @@ ICS;
         $data = chr(0xef).chr(0xbb).chr(0xbf)."BEGIN:VCALENDAR\r\nEND:VCALENDAR";
         $result = Reader::read($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -425,7 +425,7 @@ XML;
 
         $result = Reader::readXML($data);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }
@@ -446,7 +446,7 @@ XML;
 
         $result = Reader::readXML($stream);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertInstanceOf(Component::class, $result);
         $this->assertEquals('VCALENDAR', $result->name);
         $this->assertEquals(0, count($result->children()));
     }

--- a/tests/VObject/Recur/EventIterator/ByMonthInDailyTest.php
+++ b/tests/VObject/Recur/EventIterator/ByMonthInDailyTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 class ByMonthInDailyTest extends TestCase
@@ -36,7 +37,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($ics);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2013-09-28'), new DateTime('2014-09-11'));
 

--- a/tests/VObject/Recur/EventIterator/BySetPosHangTest.php
+++ b/tests/VObject/Recur/EventIterator/BySetPosHangTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 class BySetPosHangTest extends TestCase
@@ -31,7 +32,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($ics);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2015-01-01'), new DateTime('2016-01-01'));
 

--- a/tests/VObject/Recur/EventIterator/ExpandFloatingTimesTest.php
+++ b/tests/VObject/Recur/EventIterator/ExpandFloatingTimesTest.php
@@ -5,6 +5,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 use DateTime;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 class ExpandFloatingTimesTest extends TestCase
@@ -26,7 +27,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2015-01-01'), new DateTime('2015-01-31'));
         $output = <<<ICS
@@ -77,7 +78,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(
             new DateTime('2015-01-01'),

--- a/tests/VObject/Recur/EventIterator/HandleRDateExpandTest.php
+++ b/tests/VObject/Recur/EventIterator/HandleRDateExpandTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 /**
@@ -36,7 +37,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2015-01-01'), new DateTime('2015-12-01'));
 

--- a/tests/VObject/Recur/EventIterator/IncorrectExpandTest.php
+++ b/tests/VObject/Recur/EventIterator/IncorrectExpandTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 /**
@@ -34,7 +35,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2011-01-01'), new DateTime('2014-01-01'));
 

--- a/tests/VObject/Recur/EventIterator/Issue26Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue26Test.php
@@ -3,6 +3,7 @@
 namespace Sabre\VObject\Recur\EventIterator;
 
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\InvalidDataException;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
@@ -25,7 +26,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $it = new EventIterator($vcal, 'bae5d57a98');
     }

--- a/tests/VObject/Recur/EventIterator/Issue48Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue48Test.php
@@ -5,6 +5,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
 
@@ -30,7 +31,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $it = new EventIterator($vcal, 'foo');
 

--- a/tests/VObject/Recur/EventIterator/Issue50Test.php
+++ b/tests/VObject/Recur/EventIterator/Issue50Test.php
@@ -5,6 +5,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
 
@@ -104,7 +105,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $it = new EventIterator($vcal, '1aef0b27-3d92-4581-829a-11999dd36724');
 

--- a/tests/VObject/Recur/EventIterator/MissingOverriddenTest.php
+++ b/tests/VObject/Recur/EventIterator/MissingOverriddenTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Recur\EventIterator;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 
 class MissingOverriddenTest extends TestCase
@@ -33,7 +34,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $vcal = $vcal->expand(new DateTime('2011-01-01'), new DateTime('2015-01-01'));
 

--- a/tests/VObject/Recur/EventIterator/NoInstancesTest.php
+++ b/tests/VObject/Recur/EventIterator/NoInstancesTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\VObject\Recur\EventIterator;
 
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
 use Sabre\VObject\Recur\NoInstancesException;
@@ -31,7 +32,7 @@ END:VCALENDAR
 ICS;
 
         $vcal = Reader::read($input);
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCalendar', $vcal);
+        $this->assertInstanceOf(VCalendar::class, $vcal);
 
         $it = new EventIterator($vcal, 'foo');
     }

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -491,7 +491,7 @@ VCF;
 
         $vcard = Reader::read($input);
 
-        $this->assertInstanceOf('Sabre\\VObject\\Component\\VCard', $vcard);
+        $this->assertInstanceOf(Component\VCard::class, $vcard);
         $vcard = $vcard->convert(Document::VCARD40);
         $vcard = $vcard->serialize();
 


### PR DESCRIPTION
I refactored the class strings to ::class references, to enable phpstan to check their existence. This makes it easier to prevent mistakes.