### PR TITLE
Require sabre/xml 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require" : {
         "php"          : "^7.1",
         "ext-mbstring" : "*",
-        "sabre/xml"    : "^2.1"
+        "sabre/xml"    : "^2.2"
     },
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "~2.16.1",


### PR DESCRIPTION
`sabre/xml` 2.2 is the release that supports PHP 7.4.

So maybe we should require that in `composer.json` to make sure that at least 2.2 comes automagically with the current `vobject`

Probably it will get fetched anyway, just being sure.