### PR TITLE
fix an incomplete phpdoc type annotation

### DIFF
--- a/lib/Component.php
+++ b/lib/Component.php
@@ -431,7 +431,7 @@ class Component extends Node
      *
      * @param string $name
      *
-     * @return Property
+     * @return Property|null
      */
     public function __get($name)
     {


### PR DESCRIPTION
Hello,

  I use the sabre/vobject library in a couple of projects. I perform static type consistency analysis using psalm on my code, which relies on the type information specified in phpdoc comments and reports inconsistencies.

I would appreciate if you could fix the type annotation included with this pull request.