### PR TITLE
Remove US/Pacific-New obsolete timezone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --no-update --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "sabre/xml"    : "^2.1"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.16.1",
+        "friendsofphp/php-cs-fixer": "~2.16.7",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "phpstan/phpstan": "^0.12"
     },

--- a/lib/timezonedata/php-bc.php
+++ b/lib/timezonedata/php-bc.php
@@ -147,7 +147,6 @@ return [
     'US/Michigan',
     'US/Mountain',
     'US/Pacific',
-    'US/Pacific-New',
     'US/Samoa',
     'WET',
 ];


### PR DESCRIPTION
Fixes #518 and #520 

1) `US/Pacific-New` is an obsolete timezone from back in 1992 that has now been removed from the upstream timezone databases.

2) Travis now has composer major version 2.0. That complains if you do `composer remove` when there is no `composer.lock` file. Change `.travis.yml` so it does `composer remove --no-update`

3) Since composer v2.0 or some other related dependencies, "something happened" (tm) with older versions of `php-cs-fixer`. You get this sort of result:
```
$ if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
In ToolInfo.php line 50:
                         
  Undefined index: name  
                         
The command "if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi" exited with 1.
```
Actually in Travis jobs that have `--prefer-lowest` we do not really care abut running some old patch version of `php-cs-fixer`. So bump it to the current 2.16.7
