### PR TITLE
Release 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+4.3.3 (2020-11-09)
+------------------
+
+* #519: Remove US/Pacific-New obsolete timezone (@phil-davis)
+
 4.3.2 (2020-10-03)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '4.3.2';
+    const VERSION = '4.3.3';
 }


### PR DESCRIPTION
Note: this release removes an ancient (1992) and "never used" timezone that has been deprecated upstream for ages and has now been removed upstream in the "standard" timezone database, and in PHP's list of known timezones. There really should be absolutely nobody using it. So I am making this just a patch release because it fixes this for people who are updating to the latest PHP `7.*.*` patch releases, and the "backward-compatibility break" is so minor.