### PR TITLE
Fix setting properties with group assignment

### DIFF
--- a/lib/Component.php
+++ b/lib/Component.php
@@ -160,9 +160,9 @@ class Component extends Node
                     return;
                 }
             }
-        }
 
-        throw new \InvalidArgumentException('The item you passed to remove() was not a child of this component');
+            throw new \InvalidArgumentException('The item you passed to remove() was not a child of this component');
+        }
     }
 
     /**

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -72,6 +72,23 @@ class ComponentTest extends TestCase
         $this->assertEquals(null, $email3[0]->group);
     }
 
+    public function testAddGroupProperties()
+    {
+        $comp = new VCard([
+            'VERSION' => '3.0',
+            'item2.X-ABLabel' => "item2-Foo",
+        ]);
+
+        $comp->{'ITEM1.X-ABLabel'} = "ITEM1-Foo";
+
+        foreach (['item2', 'ITEM1'] as $group) {
+            $prop = $comp->{"$group.X-ABLabel"};
+            $this->assertInstanceOf(Property::class, $prop);
+            $this->assertSame("$group-Foo", (string) $prop);
+            $this->assertSame($group, $prop->group);
+        }
+    }
+
     public function testMagicIsset()
     {
         $comp = new VCalendar();

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -76,10 +76,10 @@ class ComponentTest extends TestCase
     {
         $comp = new VCard([
             'VERSION' => '3.0',
-            'item2.X-ABLabel' => "item2-Foo",
+            'item2.X-ABLabel' => 'item2-Foo',
         ]);
 
-        $comp->{'ITEM1.X-ABLabel'} = "ITEM1-Foo";
+        $comp->{'ITEM1.X-ABLabel'} = 'ITEM1-Foo';
 
         foreach (['item2', 'ITEM1'] as $group) {
             $prop = $comp->{"$group.X-ABLabel"};


### PR DESCRIPTION
Setting properties that are part of a group is broken since version 4.0.0. The `Component::remove()` method for the specific case of a property given by its name (as string) that includes a group prefix will throw an exception. However, I believe the exception is only intended for the usage of this function where the property to remove is given as an object reference, not as a string, where the given property/component is not a child of component the remove() method is called on.

Example code to trigger the exception:
```php
<?php

use Sabre\VObject;
use Sabre\VObject\Component\VCard;
include_once dirname(__FILE__) . "/vendor/autoload.php";

$vcard = new VObject\Component\VCard([
        'VERSION' => '3.0',
        'item2.X-ABLabel' => "Foo", // triggers exception
]);

$vcard->{"item1.X-ABLabel"} = "SpecialLabel"; // also triggers exception

print $vcard->serialize();
```

The exception will be triggered for both the usage in the constructor as well as by a separate set operation.