### PR TITLE
Use latest php-cs-fixer 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ ChangeLog
 ------------------
 
 * #469, #451: fix compat with php 7.4
-* #443: prevent running in indefinte loop
+* #443: prevent running in indefinite loop
 * #449: Preventing creating a component for a root document
 * #450: Fix parse with option Forgiving with trailing equal
 * #459: fixed typo in VCalendar which resulting in usage of the wrong TimeZone
@@ -125,7 +125,7 @@ ChangeLog
 * #306: iTip REPLYs to the first instance of a recurring event was not handled
   correctly.
 * Slightly better error message during validation of `N` and `ADR` properties.
-* #312: Correctly extracing timezone in the iTip broker, even when we don't
+* #312: Correctly extracting timezone in the iTip broker, even when we don't
   have a master event. (@vkomrakov-sugar).
 * When validating a component's property that must appear once and which could
   automatically be repaired, make sure we report the change as 'repaired'.
@@ -447,7 +447,7 @@ ChangeLog
 * #114: VTIMEZONE is retained when generating new REQUEST objects.
 * #114: Support for 'MAILTO:' style email addresses (in uppercase) in the iTip
   broker. This improves evolution support.
-* #115: Using REQUEST-STATUS from REPLY messages and now propegating that into
+* #115: Using REQUEST-STATUS from REPLY messages and now propagating that into
   SCHEDULE-STATUS.
 
 
@@ -684,7 +684,7 @@ ChangeLog
 3.0.0-alpha2 (2013-05-22)
 -------------------------
 
-* Fixed: vCard URL properties were referencing a non-existant class.
+* Fixed: vCard URL properties were referencing a non-existent class.
 
 
 3.0.0-alpha1 (2013-05-21)
@@ -842,7 +842,7 @@ ChangeLog
   properties such as N, ADR, ORG and CATEGORIES.
 * Added: Splitter classes, that can split up large objects (such as exports)
   into individual objects (thanks @DominikTo and @armin-hackmann).
-* Added: VFREEBUSY component, which allows easily checking wether timeslots are
+* Added: VFREEBUSY component, which allows easily checking whether timeslots are
   available.
 * Added: The Reader class now has a 'FORGIVING' option, which allows it to parse
   properties with incorrect characters in the name (at this time, it just allows

--- a/bin/bench_freebusygenerator.php
+++ b/bin/bench_freebusygenerator.php
@@ -11,7 +11,7 @@ if ($argc < 2) {
     echo "The process will be repeated 100 times to get accurate stats\n";
     echo "\n";
     echo 'Usage: '.$argv[0]." inputfile.ics\n";
-    die();
+    exit();
 }
 
 list(, $inputFile) = $argv;

--- a/bin/bench_manipulatevcard.php
+++ b/bin/bench_manipulatevcard.php
@@ -10,7 +10,7 @@ if ($argc < 2) {
     echo 'system.';
     echo "\n";
     echo 'Usage: '.$argv[0]." inputfile.vcf\n";
-    die();
+    exit();
 }
 
 list(, $inputFile) = $argv;

--- a/bin/fetch_windows_zones.php
+++ b/bin/fetch_windows_zones.php
@@ -1,13 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-$windowsZonesUrl = 'http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml';
+$windowsZonesUrl = 'https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml';
 $outputFile = __DIR__.'/../lib/timezonedata/windowszones.php';
 
 echo 'Fetching timezone map from: '.$windowsZonesUrl, "\n";
 
 $data = file_get_contents($windowsZonesUrl);
-
 $xml = simplexml_load_string($data);
 
 $map = [];
@@ -44,6 +43,6 @@ fclose($f);
 
 echo "Formatting\n";
 
-exec(__DIR__.'/sabre-cs-fixer fix '.escapeshellarg($outputFile));
+exec(__DIR__.'/../vendor/bin/php-cs-fixer fix '.escapeshellarg($outputFile));
 
 echo "Done\n";

--- a/bin/generateicalendardata.php
+++ b/bin/generateicalendardata.php
@@ -18,7 +18,7 @@ The iCalendar output goes to stdout. Other messages to stderr.
 
 HI
     );
-    die();
+    exit();
 }
 
 $events = 100;
@@ -77,7 +77,7 @@ $result = $calendar->validate();
 if ($result) {
     fwrite(STDERR, "Errors!\n");
     fwrite(STDERR, print_r($result, true));
-    die(-1);
+    exit(-1);
 }
 
 fwrite(STDERR, "Serializing this beast\n");

--- a/bin/mergeduplicates.php
+++ b/bin/mergeduplicates.php
@@ -19,7 +19,7 @@ foreach ($paths as $path) {
 
 if (!class_exists('Sabre\\VObject\\Version')) {
     fwrite(STDERR, "Composer autoloader could not be loaded.\n");
-    die(1);
+    exit(1);
 }
 
 echo 'sabre/vobject ', Version::VERSION, " duplicate contact merge tool\n";
@@ -27,7 +27,7 @@ echo 'sabre/vobject ', Version::VERSION, " duplicate contact merge tool\n";
 if ($argc < 3) {
     echo "\n";
     echo 'Usage: ', $argv[0], " input.vcf output.vcf [debug.log]\n";
-    die(1);
+    exit(1);
 }
 
 $input = fopen($argv[1], 'r');

--- a/bin/rrulebench.php
+++ b/bin/rrulebench.php
@@ -9,7 +9,7 @@ if ($argc < 4) {
     echo 'system.';
     echo "\n";
     echo 'Usage: '.$argv[0]." inputfile.ics startdate enddate\n";
-    die();
+    exit();
 }
 
 list(, $inputFile, $startDate, $endDate) = $argv;

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "sabre/xml"    : "^2.1"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.16.7",
+        "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "phpstan/phpstan": "^0.12"
     },

--- a/lib/Cli.php
+++ b/lib/Cli.php
@@ -206,7 +206,7 @@ class Cli
             }
 
             if (!in_array($positional[0], ['validate', 'repair', 'convert', 'color'])) {
-                throw new InvalidArgumentException('Uknown command: '.$positional[0]);
+                throw new InvalidArgumentException('Unknown command: '.$positional[0]);
             }
         } catch (InvalidArgumentException $e) {
             $this->showHelp();

--- a/lib/Cli.php
+++ b/lib/Cli.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\VObject;
 
-use
-    InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * This is the CLI interface for sabre-vobject.
@@ -137,17 +136,14 @@ class Cli
                             // jcard/jcal documents
                             case 'jcard':
                             case 'jcal':
-
                             // specific document versions
                             case 'vcard21':
                             case 'vcard30':
                             case 'vcard40':
                             case 'icalendar20':
-
                             // specific formats
                             case 'json':
                             case 'mimedir':
-
                             // icalendar/vcad
                             case 'icalendar':
                             case 'vcard':
@@ -183,7 +179,6 @@ class Cli
                             case 'vcard30':
                             case 'vcard40':
                             case 'icalendar20':
-
                                 $this->inputFormat = 'mimedir';
                                 break;
 

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -309,7 +309,7 @@ class VCalendar extends VObject\Document
 
         foreach ($this->children() as $child) {
             if ($child instanceof Property && 'PRODID' !== $child->name) {
-                // We explictly want to ignore PRODID, because we want to
+                // We explicitly want to ignore PRODID, because we want to
                 // overwrite it with our own.
                 $newChildren[] = clone $child;
             } elseif ($child instanceof Component && 'VTIMEZONE' !== $child->name) {

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -373,7 +373,7 @@ class VCard extends VObject\Document
     /**
      * Returns a preferred field.
      *
-     * VCards can indicate wether a field such as ADR, TEL or EMAIL is
+     * VCards can indicate whether a field such as ADR, TEL or EMAIL is
      * preferred by specifying TYPE=PREF (vcard 2.1, 3) or PREF=x (vcard 4, x
      * being a number between 1 and 100).
      *

--- a/lib/FreeBusyData.php
+++ b/lib/FreeBusyData.php
@@ -84,7 +84,7 @@ class FreeBusyData
             'type' => $type,
         ];
 
-        $preceedingItem = $this->data[$insertStartIndex - 1];
+        $precedingItem = $this->data[$insertStartIndex - 1];
         if ($this->data[$insertStartIndex - 1]['start'] === $start) {
             // The old item starts at the exact same point as the new item.
             --$insertStartIndex;
@@ -122,11 +122,11 @@ class FreeBusyData
         // between.
         if (-1 === $itemsToDelete) {
             $itemsToDelete = 0;
-            if ($newItem['end'] < $preceedingItem['end']) {
+            if ($newItem['end'] < $precedingItem['end']) {
                 $newItems[] = [
                     'start' => $newItem['end'] + 1,
-                    'end' => $preceedingItem['end'],
-                    'type' => $preceedingItem['type'],
+                    'end' => $precedingItem['end'],
+                    'type' => $precedingItem['type'],
                 ];
             }
         }

--- a/lib/FreeBusyGenerator.php
+++ b/lib/FreeBusyGenerator.php
@@ -126,7 +126,7 @@ class FreeBusyGenerator
     /**
      * Sets the input objects.
      *
-     * You must either specify a valendar object as a string, or as the parse
+     * You must either specify a vcalendar object as a string, or as the parse
      * Component.
      * It's also possible to specify multiple objects as an array.
      *

--- a/lib/FreeBusyGenerator.php
+++ b/lib/FreeBusyGenerator.php
@@ -362,7 +362,6 @@ class FreeBusyGenerator
             foreach ($object->getBaseComponents() as $component) {
                 switch ($component->name) {
                     case 'VEVENT':
-
                         $FBTYPE = 'BUSY';
                         if (isset($component->TRANSP) && ('TRANSPARENT' === strtoupper($component->TRANSP))) {
                             break;

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -293,7 +293,7 @@ class Parameter extends Node
                 // https://tools.ietf.org/html/rfc6868
                 //
                 // But we've found that iCal (7.0, shipped with OSX 10.9)
-                // severaly trips on + characters not being quoted, so we
+                // severely trips on + characters not being quoted, so we
                 // added + as well.
                 if (!preg_match('#(?: [\n":;\^,\+] )#x', $item)) {
                     return $out.$item;

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -95,13 +95,11 @@ class Parameter extends Node
             case 'WORK':
             case 'HOME':
             case 'PREF':
-
             // Delivery Label Type
             case 'DOM':
             case 'INTL':
             case 'POSTAL':
             case 'PARCEL':
-
             // Telephone types
             case 'VOICE':
             case 'FAX':
@@ -113,7 +111,6 @@ class Parameter extends Node
             case 'CAR':
             case 'ISDN':
             case 'VIDEO':
-
             // EMAIL types (lol)
             case 'AOL':
             case 'APPLELINK':
@@ -127,7 +124,6 @@ class Parameter extends Node
             case 'PRODIGY':
             case 'TLX':
             case 'X400':
-
             // Photo / Logo format types
             case 'GIF':
             case 'CGM':
@@ -143,12 +139,10 @@ class Parameter extends Node
             case 'MPEG2':
             case 'AVI':
             case 'QTIME':
-
             // Sound Digital Audio Type
             case 'WAVE':
             case 'PCM':
             case 'AIFF':
-
             // Key types
             case 'X509':
             case 'PGP':

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -343,7 +343,7 @@ class MimeDir extends Parser
             ) (?=[;:,])
             /xi";
 
-        //echo $regex, "\n"; die();
+        //echo $regex, "\n"; exit();
         preg_match_all($regex, $line, $matches, PREG_SET_ORDER);
 
         $property = [

--- a/lib/Property/Boolean.php
+++ b/lib/Property/Boolean.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\VObject\Property;
 
-use
-    Sabre\VObject\Property;
+use Sabre\VObject\Property;
 
 /**
  * Boolean property.

--- a/lib/Property/ICalendar/CalAddress.php
+++ b/lib/Property/ICalendar/CalAddress.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
-use
-    Sabre\VObject\Property\Text;
+use Sabre\VObject\Property\Text;
 
 /**
  * CalAddress property.

--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -184,7 +184,7 @@ class DateTime extends Property
      * Sets the property as multiple date-time objects.
      *
      * The first value will be used as a reference for the timezones, and all
-     * the otehr values will be adjusted for that timezone
+     * the other values will be adjusted for that timezone
      *
      * @param DateTimeInterface[] $dt
      * @param bool isFloating If set to true, timezones will be ignored

--- a/lib/Property/IntegerValue.php
+++ b/lib/Property/IntegerValue.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\VObject\Property;
 
-use
-    Sabre\VObject\Property;
+use Sabre\VObject\Property;
 
 /**
  * Integer property.

--- a/lib/Property/VCard/LanguageTag.php
+++ b/lib/Property/VCard/LanguageTag.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\VObject\Property\VCard;
 
-use
-    Sabre\VObject\Property;
+use Sabre\VObject\Property;
 
 /**
  * LanguageTag property.

--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -83,7 +83,7 @@ class EventIterator implements \Iterator
      * 2. You can pass an array of VEVENTs (all UIDS should match).
      * 3. You can pass a single VEVENT component.
      *
-     * Only the second method is recomended. The other 1 and 3 will be removed
+     * Only the second method is recommended. The other 1 and 3 will be removed
      * at some point in the future.
      *
      * The $uid parameter is only required for the first method.

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -717,7 +717,6 @@ class RRuleIterator implements Iterator
                     break;
 
                 case 'INTERVAL':
-
                 case 'COUNT':
                     $val = (int) $value;
                     if ($val < 1) {

--- a/lib/timezonedata/windowszones.php
+++ b/lib/timezonedata/windowszones.php
@@ -3,10 +3,10 @@
 /**
  * Automatically generated timezone file.
  *
- * Last update: 2016-08-24T17:35:38-04:00
- * Source: http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml
+ * Last update: 2020-12-13T17:38:12+05:45
+ * Source: https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml
  *
- * @copyright Copyright (C) 2011-2015 fruux GmbH (https://fruux.com/).
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/).
  * @license http://sabre.io/license/ Modified BSD License
  */
 
@@ -74,6 +74,7 @@ return [
   'Line Islands Standard Time' => 'Pacific/Kiritimati',
   'Lord Howe Standard Time' => 'Australia/Lord_Howe',
   'Magadan Standard Time' => 'Asia/Magadan',
+  'Magallanes Standard Time' => 'America/Punta_Arenas',
   'Marquesas Standard Time' => 'Pacific/Marquesas',
   'Mauritius Standard Time' => 'Indian/Mauritius',
   'Middle East Standard Time' => 'Asia/Beirut',
@@ -91,11 +92,13 @@ return [
   'North Asia East Standard Time' => 'Asia/Irkutsk',
   'North Asia Standard Time' => 'Asia/Krasnoyarsk',
   'North Korea Standard Time' => 'Asia/Pyongyang',
+  'Omsk Standard Time' => 'Asia/Omsk',
   'Pacific SA Standard Time' => 'America/Santiago',
   'Pacific Standard Time' => 'America/Los_Angeles',
   'Pacific Standard Time (Mexico)' => 'America/Tijuana',
   'Pakistan Standard Time' => 'Asia/Karachi',
   'Paraguay Standard Time' => 'America/Asuncion',
+  'Qyzylorda Standard Time' => 'Asia/Qyzylorda',
   'Romance Standard Time' => 'Europe/Paris',
   'Russia Time Zone 10' => 'Asia/Srednekolymsk',
   'Russia Time Zone 11' => 'Asia/Kamchatka',
@@ -108,9 +111,12 @@ return [
   'Saint Pierre Standard Time' => 'America/Miquelon',
   'Sakhalin Standard Time' => 'Asia/Sakhalin',
   'Samoa Standard Time' => 'Pacific/Apia',
+  'Sao Tome Standard Time' => 'Africa/Sao_Tome',
+  'Saratov Standard Time' => 'Europe/Saratov',
   'Singapore Standard Time' => 'Asia/Singapore',
   'South Africa Standard Time' => 'Africa/Johannesburg',
   'Sri Lanka Standard Time' => 'Asia/Colombo',
+  'Sudan Standard Time' => 'Africa/Khartoum',
   'Syria Standard Time' => 'Asia/Damascus',
   'Taipei Standard Time' => 'Asia/Taipei',
   'Tasmania Standard Time' => 'Australia/Hobart',
@@ -125,6 +131,7 @@ return [
   'US Mountain Standard Time' => 'America/Phoenix',
   'UTC' => 'Etc/GMT',
   'UTC+12' => 'Etc/GMT-12',
+  'UTC+13' => 'Etc/GMT-13',
   'UTC-02' => 'Etc/GMT+2',
   'UTC-08' => 'Etc/GMT+8',
   'UTC-09' => 'Etc/GMT+9',
@@ -132,6 +139,7 @@ return [
   'Ulaanbaatar Standard Time' => 'Asia/Ulaanbaatar',
   'Venezuela Standard Time' => 'America/Caracas',
   'Vladivostok Standard Time' => 'Asia/Vladivostok',
+  'Volgograd Standard Time' => 'Europe/Volgograd',
   'W. Australia Standard Time' => 'Australia/Perth',
   'W. Central Africa Standard Time' => 'Africa/Lagos',
   'W. Europe Standard Time' => 'Europe/Berlin',
@@ -140,4 +148,5 @@ return [
   'West Bank Standard Time' => 'Asia/Hebron',
   'West Pacific Standard Time' => 'Pacific/Port_Moresby',
   'Yakutsk Standard Time' => 'Asia/Yakutsk',
+  'Yukon Standard Time' => 'America/Whitehorse',
 ];

--- a/lib/timezonedata/windowszones.php
+++ b/lib/timezonedata/windowszones.php
@@ -10,7 +10,7 @@
  * @license http://sabre.io/license/ Modified BSD License
  */
 
-return  [
+return [
   'AUS Central Standard Time' => 'Australia/Darwin',
   'AUS Eastern Standard Time' => 'Australia/Sydney',
   'Afghanistan Standard Time' => 'Asia/Kabul',

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -122,7 +122,7 @@ VCAL;
         );
     }
 
-    public function testRFCxxxSection3_1_availabilityprop_required()
+    public function testRFCxxxSection3Part1AvailabilitypropRequired()
     {
         // UID and DTSTAMP are present.
         $this->assertIsValid(Reader::read(
@@ -177,7 +177,7 @@ VCAL
         ));
     }
 
-    public function testRFCxxxSection3_1_availabilityprop_optional_once()
+    public function testRFCxxxSection3Part1AvailabilitypropOptionalOnce()
     {
         $properties = [
             'BUSYTYPE:BUSY',
@@ -205,7 +205,7 @@ VCAL
         }
     }
 
-    public function testRFCxxxSection3_1_availabilityprop_dtend_duration()
+    public function testRFCxxxSection3Part1AvailabilitypropDtendDuration()
     {
         // Only DTEND.
         $this->assertIsValid(Reader::read($this->template([
@@ -239,7 +239,7 @@ VCAL;
         $this->assertInstanceOf(Available::class, $document->VAVAILABILITY->AVAILABLE);
     }
 
-    public function testRFCxxxSection3_1_availableprop_required()
+    public function testRFCxxxSection3Part1AvailablepropRequired()
     {
         // UID, DTSTAMP and DTSTART are present.
         $this->assertIsValid(Reader::read(
@@ -331,7 +331,7 @@ VCAL
         ));
     }
 
-    public function testRFCxxxSection3_1_available_dtend_duration()
+    public function testRFCxxxSection3Part1AvailableDtendDuration()
     {
         // Only DTEND.
         $this->assertIsValid(Reader::read($this->templateAvailable([
@@ -350,7 +350,7 @@ VCAL
         ])));
     }
 
-    public function testRFCxxxSection3_1_available_optional_once()
+    public function testRFCxxxSection3Part1AvailableOptionalOnce()
     {
         $properties = [
             'CREATED:20111005T135125Z',
@@ -373,7 +373,7 @@ VCAL
         }
     }
 
-    public function testRFCxxxSection3_2()
+    public function testRFCxxxSection3Part2()
     {
         $this->assertEquals(
             'BUSY',

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -135,8 +135,8 @@ VCF;
         $vcard = VObject\Reader::read($vcard);
         $this->assertEquals('1@example.org', $vcard->getByType('EMAIL', 'home')->getValue());
         $this->assertEquals('2@example.org', $vcard->getByType('EMAIL', 'work')->getValue());
-        $this->assertNull($vcard->getByType('EMAIL', 'non-existant'));
-        $this->assertNull($vcard->getByType('ADR', 'non-existant'));
+        $this->assertNull($vcard->getByType('EMAIL', 'non-existent'));
+        $this->assertNull($vcard->getByType('ADR', 'non-existent'));
     }
 
     public function testPreferredNoPref()

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -408,7 +408,7 @@ class DateTimeParserTest extends TestCase
         ];
     }
 
-    public function testDateAndOrTime_DateWithYearMonthDay()
+    public function testDateAndOrTimeDateWithYearMonthDay()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '20150128',
@@ -420,7 +420,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateWithYearMonth()
+    public function testDateAndOrTimeDateWithYearMonth()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '2015-01',
@@ -431,7 +431,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateWithMonth()
+    public function testDateAndOrTimeDateWithMonth()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '--01',
@@ -441,7 +441,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateWithMonthDay()
+    public function testDateAndOrTimeDateWithMonthDay()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '--0128',
@@ -452,7 +452,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateWithDay()
+    public function testDateAndOrTimeDateWithDay()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28',
@@ -462,7 +462,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithHour()
+    public function testDateAndOrTimeTimeWithHour()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '13',
@@ -472,7 +472,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithHourMinute()
+    public function testDateAndOrTimeTimeWithHourMinute()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '1353',
@@ -483,7 +483,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithHourSecond()
+    public function testDateAndOrTimeTimeWithHourSecond()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '135301',
@@ -495,7 +495,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithMinute()
+    public function testDateAndOrTimeTimeWithMinute()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '-53',
@@ -505,7 +505,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithMinuteSecond()
+    public function testDateAndOrTimeTimeWithMinuteSecond()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '-5301',
@@ -516,7 +516,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithSecond()
+    public function testDateAndOrTimeTimeWithSecond()
     {
         $this->assertTrue(true);
 
@@ -526,7 +526,7 @@ class DateTimeParserTest extends TestCase
          */
     }
 
-    public function testDateAndOrTime_TimeWithSecondZ()
+    public function testDateAndOrTimeTimeWithSecondZ()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '--01Z',
@@ -537,7 +537,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_TimeWithSecondTZ()
+    public function testDateAndOrTimeTimeWithSecondTZ()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '--01+1234',
@@ -548,7 +548,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithYearMonthDayHour()
+    public function testDateAndOrTimeDateTimeWithYearMonthDayHour()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '20150128T13',
@@ -561,7 +561,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithMonthDayHour()
+    public function testDateAndOrTimeDateTimeWithMonthDayHour()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '--0128T13',
@@ -573,7 +573,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithDayHour()
+    public function testDateAndOrTimeDateTimeWithDayHour()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28T13',
@@ -584,7 +584,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithDayHourMinute()
+    public function testDateAndOrTimeDateTimeWithDayHourMinute()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28T1353',
@@ -596,7 +596,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithDayHourMinuteSecond()
+    public function testDateAndOrTimeDateTimeWithDayHourMinuteSecond()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28T135301',
@@ -609,7 +609,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithDayHourZ()
+    public function testDateAndOrTimeDateTimeWithDayHourZ()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28T13Z',
@@ -621,7 +621,7 @@ class DateTimeParserTest extends TestCase
         );
     }
 
-    public function testDateAndOrTime_DateTimeWithDayHourTZ()
+    public function testDateAndOrTimeDateTimeWithDayHourTZ()
     {
         $this->assertDateAndOrTimeEqualsTo(
             '---28T13+1234',

--- a/tests/VObject/EmptyValueIssueTest.php
+++ b/tests/VObject/EmptyValueIssueTest.php
@@ -17,7 +17,7 @@ class EmptyValueIssueTest extends TestCase
 BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
-DESCRIPTION:This is a descpription\\nwith a linebreak and a \\; \\, and :
+DESCRIPTION:This is a description\\nwith a linebreak and a \\; \\, and :
 END:VEVENT
 END:VCALENDAR
 ICS;
@@ -25,6 +25,6 @@ ICS;
         $vobj = Reader::read($input);
 
         // Before this bug was fixed, getValue() would return nothing.
-        $this->assertEquals("This is a descpription\nwith a linebreak and a ; , and :", $vobj->VEVENT->DESCRIPTION->getValue());
+        $this->assertEquals("This is a description\nwith a linebreak and a ; , and :", $vobj->VEVENT->DESCRIPTION->getValue());
     }
 }

--- a/tests/VObject/ITip/BrokerAttendeeReplyTest.php
+++ b/tests/VObject/ITip/BrokerAttendeeReplyTest.php
@@ -907,7 +907,7 @@ ICS;
      * Except in this case, there was already an overridden event, and the
      * overridden event was marked as cancelled by the attendee.
      *
-     * For any other attendence status, the new status would have been
+     * For any other attendance status, the new status would have been
      * declined, but for this, no message should we sent.
      */
     public function testDontCreateReplyWhenEventWasDeclined()

--- a/tests/VObject/ITip/BrokerProcessReplyTest.php
+++ b/tests/VObject/ITip/BrokerProcessReplyTest.php
@@ -373,7 +373,7 @@ ICS;
         $result = $this->process($itip, $old, $expected);
     }
 
-    public function testReplyPartyCrashCreateExcepton()
+    public function testReplyPartyCrashCreateException()
     {
         // IN this test there's a recurring event that has an exception. The
         // exception is missing the attendee.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -262,7 +262,7 @@ XML;
     /**
      * iCalendar Stream.
      */
-    public function testRFC6321Section3_2()
+    public function testRFC6321Section3Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -280,7 +280,7 @@ XML
     /**
      * All components exist.
      */
-    public function testRFC6321Section3_3()
+    public function testRFC6321Section3Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -325,7 +325,7 @@ XML
     /**
      * Properties, Special Cases, GEO.
      */
-    public function testRFC6321Section3_4_1_2()
+    public function testRFC6321Section3Part4Part1Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -351,7 +351,7 @@ XML
     /**
      * Properties, Special Cases, REQUEST-STATUS.
      */
-    public function testRFC6321Section3_4_1_3()
+    public function testRFC6321Section3Part4Part1Part3()
     {
         // Example 1 of RFC5545, Section 3.8.8.3.
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -466,7 +466,7 @@ XML
     /**
      * Values, Binary.
      */
-    public function testRFC6321Section3_6_1()
+    public function testRFC6321Section3Part6Part1()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -511,7 +511,7 @@ XML
     /**
      * Values, Boolean.
      */
-    public function testRFC6321Section3_6_2()
+    public function testRFC6321Section3Part6Part2()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -539,7 +539,7 @@ XML
     /**
      * Values, Calendar User Address.
      */
-    public function testRFC6321Section3_6_3()
+    public function testRFC6321Section3Part6Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -564,7 +564,7 @@ XML
     /**
      * Values, Date.
      */
-    public function testRFC6321Section3_6_4()
+    public function testRFC6321Section3Part6Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -589,7 +589,7 @@ XML
     /**
      * Values, Date-Time.
      */
-    public function testRFC6321Section3_6_5()
+    public function testRFC6321Section3Part6Part5()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -614,7 +614,7 @@ XML
     /**
      * Values, Duration.
      */
-    public function testRFC6321Section3_6_6()
+    public function testRFC6321Section3Part6Part6()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -639,16 +639,16 @@ XML
     /**
      * Values, Float.
      */
-    public function testRFC6321Section3_6_7()
+    public function testRFC6321Section3Part6Part7()
     {
         // GEO uses <float /> with a positive and a non-negative numbers.
-        $this->testRFC6321Section3_4_1_2();
+        $this->testRFC6321Section3Part4Part1Part2();
     }
 
     /**
      * Values, Integer.
      */
-    public function testRFC6321Section3_6_8()
+    public function testRFC6321Section3Part6Part8()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -692,7 +692,7 @@ XML
     /**
      * Values, Period of Time.
      */
-    public function testRFC6321Section3_6_9()
+    public function testRFC6321Section3Part6Part9()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -742,7 +742,7 @@ XML
     /**
      * Values, Recurrence Rule.
      */
-    public function testRFC6321Section3_6_10()
+    public function testRFC6321Section3Part6Part10()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -772,7 +772,7 @@ XML
     /**
      * Values, Text.
      */
-    public function testRFC6321Section3_6_11()
+    public function testRFC6321Section3Part6Part11()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -797,7 +797,7 @@ XML
     /**
      * Values, Time.
      */
-    public function testRFC6321Section3_6_12()
+    public function testRFC6321Section3Part6Part12()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -822,7 +822,7 @@ XML
     /**
      * Values, URI.
      */
-    public function testRFC6321Section3_6_13()
+    public function testRFC6321Section3Part6Part13()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -847,7 +847,7 @@ XML
     /**
      * Values, UTC Offset.
      */
-    public function testRFC6321Section3_6_14()
+    public function testRFC6321Section3Part6Part14()
     {
         // Example 1 of RFC5545, Section 3.3.14.
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1259,7 +1259,7 @@ XML
     /**
      * Extensibility.
      */
-    public function testRFC6351Section5_1_NoNamespace()
+    public function testRFC6351Section5Part1NoNamespace()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -1777,7 +1777,7 @@ XML
     /**
      * Property: SOURCE.
      */
-    public function testRFC6350Section6_1_3()
+    public function testRFC6350Section6Part1Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1801,7 +1801,7 @@ XML
     /**
      * Property: KIND.
      */
-    public function testRFC6350Section6_1_4()
+    public function testRFC6350Section6Part1Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1825,7 +1825,7 @@ XML
     /**
      * Property: FN.
      */
-    public function testRFC6350Section6_2_1()
+    public function testRFC6350Section6Part2Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1849,7 +1849,7 @@ XML
     /**
      * Property: N.
      */
-    public function testRFC6350Section6_2_2()
+    public function testRFC6350Section6Part2Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1877,7 +1877,7 @@ XML
     /**
      * Property: NICKNAME.
      */
-    public function testRFC6350Section6_2_3()
+    public function testRFC6350Section6Part2Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1902,7 +1902,7 @@ XML
     /**
      * Property: PHOTO.
      */
-    public function testRFC6350Section6_2_4()
+    public function testRFC6350Section6Part2Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1923,7 +1923,7 @@ XML
         );
     }
 
-    public function testRFC6350Section6_2_5()
+    public function testRFC6350Section6Part2Part5()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1944,7 +1944,7 @@ XML
         );
     }
 
-    public function testRFC6350Section6_2_6()
+    public function testRFC6350Section6Part2Part6()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1968,7 +1968,7 @@ XML
     /**
      * Property: GENDER.
      */
-    public function testRFC6350Section6_2_7()
+    public function testRFC6350Section6Part2Part7()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -1993,7 +1993,7 @@ XML
     /**
      * Property: ADR.
      */
-    public function testRFC6350Section6_3_1()
+    public function testRFC6350Section6Part3Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2023,7 +2023,7 @@ XML
     /**
      * Property: TEL.
      */
-    public function testRFC6350Section6_4_1()
+    public function testRFC6350Section6Part4Part1()
     {
         /*
          * Quoting RFC:
@@ -2085,7 +2085,7 @@ XML
     /**
      * Property: EMAIL.
      */
-    public function testRFC6350Section6_4_2()
+    public function testRFC6350Section6Part4Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2114,7 +2114,7 @@ XML
     /**
      * Property: IMPP.
      */
-    public function testRFC6350Section6_4_3()
+    public function testRFC6350Section6Part4Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2143,7 +2143,7 @@ XML
     /**
      * Property: LANG.
      */
-    public function testRFC6350Section6_4_4()
+    public function testRFC6350Section6Part4Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2175,7 +2175,7 @@ XML
     /**
      * Property: TZ.
      */
-    public function testRFC6350Section6_5_1()
+    public function testRFC6350Section6Part5Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2199,7 +2199,7 @@ XML
     /**
      * Property: GEO.
      */
-    public function testRFC6350Section6_5_2()
+    public function testRFC6350Section6Part5Part2()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -2241,7 +2241,7 @@ XML
     /**
      * Property: TITLE.
      */
-    public function testRFC6350Section6_6_1()
+    public function testRFC6350Section6Part6Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2265,7 +2265,7 @@ XML
     /**
      * Property: ROLE.
      */
-    public function testRFC6350Section6_6_2()
+    public function testRFC6350Section6Part6Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2289,7 +2289,7 @@ XML
     /**
      * Property: LOGO.
      */
-    public function testRFC6350Section6_6_3()
+    public function testRFC6350Section6Part6Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2313,7 +2313,7 @@ XML
     /**
      * Property: ORG.
      */
-    public function testRFC6350Section6_6_4()
+    public function testRFC6350Section6Part6Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2339,7 +2339,7 @@ XML
     /**
      * Property: MEMBER.
      */
-    public function testRFC6350Section6_6_5()
+    public function testRFC6350Section6Part6Part5()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2393,7 +2393,7 @@ XML
     /**
      * Property: RELATED.
      */
-    public function testRFC6350Section6_6_6()
+    public function testRFC6350Section6Part6Part6()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2422,7 +2422,7 @@ XML
     /**
      * Property: CATEGORIES.
      */
-    public function testRFC6350Section6_7_1()
+    public function testRFC6350Section6Part7Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2449,7 +2449,7 @@ XML
     /**
      * Property: NOTE.
      */
-    public function testRFC6350Section6_7_2()
+    public function testRFC6350Section6Part7Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2473,7 +2473,7 @@ XML
     /**
      * Property: PRODID.
      */
-    public function testRFC6350Section6_7_3()
+    public function testRFC6350Section6Part7Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2494,7 +2494,7 @@ XML
         );
     }
 
-    public function testRFC6350Section6_7_4()
+    public function testRFC6350Section6Part7Part4()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2518,7 +2518,7 @@ XML
     /**
      * Property: SOUND.
      */
-    public function testRFC6350Section6_7_5()
+    public function testRFC6350Section6Part7Part5()
     {
         $this->assertXMLEqualsToMimeDir(
 <<<XML
@@ -2560,7 +2560,7 @@ XML
     /**
      * Property: UID.
      */
-    public function testRFC6350Section6_7_6()
+    public function testRFC6350Section6Part7Part6()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2584,7 +2584,7 @@ XML
     /**
      * Property: CLIENTPIDMAP.
      */
-    public function testRFC6350Section6_7_7()
+    public function testRFC6350Section6Part7Part7()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2609,7 +2609,7 @@ XML
     /**
      * Property: URL.
      */
-    public function testRFC6350Section6_7_8()
+    public function testRFC6350Section6Part7Part8()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2633,7 +2633,7 @@ XML
     /**
      * Property: VERSION.
      */
-    public function testRFC6350Section6_7_9()
+    public function testRFC6350Section6Part7Part9()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2652,7 +2652,7 @@ XML
     /**
      * Property: KEY.
      */
-    public function testRFC6350Section6_8_1()
+    public function testRFC6350Section6Part8Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2681,7 +2681,7 @@ XML
     /**
      * Property: FBURL.
      */
-    public function testRFC6350Section6_9_1()
+    public function testRFC6350Section6Part9Part1()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2710,7 +2710,7 @@ XML
     /**
      * Property: CALADRURI.
      */
-    public function testRFC6350Section6_9_2()
+    public function testRFC6350Section6Part9Part2()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2734,7 +2734,7 @@ XML
     /**
      * Property: CALURI.
      */
-    public function testRFC6350Section6_9_3()
+    public function testRFC6350Section6Part9Part3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
@@ -2763,7 +2763,7 @@ XML
     /**
      * Property: CAPURI.
      */
-    public function testRFC6350SectionA_3()
+    public function testRFC6350SectionAPart3()
     {
         $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -336,7 +336,7 @@ class ReaderTest extends TestCase
         $data = [
             'BEGIN:VCALENDAR',
             'DESCRIPTION:propValue',
-            "Yes, we've actually seen a file with non-idented property values on multiple lines",
+            "Yes, we've actually seen a file with non-indented property values on multiple lines",
             'END:VCALENDAR',
         ];
 

--- a/tests/VObject/Recur/EventIterator/MainTest.php
+++ b/tests/VObject/Recur/EventIterator/MainTest.php
@@ -1172,7 +1172,7 @@ class MainTest extends TestCase
     /**
      * @depends testValues
      */
-    public function testOverridenEvent()
+    public function testOverriddenEvent()
     {
         $vcal = new VCalendar();
 
@@ -1243,7 +1243,7 @@ class MainTest extends TestCase
     /**
      * @depends testValues
      */
-    public function testOverridenEvent2()
+    public function testOverriddenEvent2()
     {
         $vcal = new VCalendar();
 
@@ -1291,7 +1291,7 @@ class MainTest extends TestCase
     /**
      * @depends testValues
      */
-    public function testOverridenEventNoValuesExpected()
+    public function testOverriddenEventNoValuesExpected()
     {
         $vcal = new VCalendar();
         $ev1 = $vcal->createComponent('VEVENT');
@@ -1318,12 +1318,12 @@ class MainTest extends TestCase
         $summaries = [];
 
         // The reported problem was specifically related to the VCALENDAR
-        // expansion. In this parcitular case, we had to forward to the 28th of
+        // expansion. In this particular case, we had to forward to the 28th of
         // january.
         $it->fastForward(new DateTimeImmutable('2012-01-28 23:00:00'));
 
-        // We stop the loop when it hits the 6th of februari. Normally this
-        // iterator would hit 24, 25 (overriden from 31) and 7 feb but because
+        // We stop the loop when it hits the 6th of February. Normally this
+        // iterator would hit 24, 25 (overridden from 31) and 7 feb but because
         // we 'filter' from the 28th till the 6th, we should get 0 results.
         while ($it->valid() && $it->getDTStart() < new DateTimeImmutable('2012-02-06 23:00:00')) {
             $dates[] = $it->getDTStart();

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -265,7 +265,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    public function testMonlthyEndOfMonth()
+    public function testMonthlyEndOfMonth()
     {
         $this->parse(
             'FREQ=MONTHLY;INTERVAL=2;COUNT=12',
@@ -628,7 +628,7 @@ class RRuleIteratorTest extends TestCase
      * This bug came from a Fruux customer. This would result in a never-ending
      * request.
      */
-    public function testFastFowardTooFar()
+    public function testFastForwardTooFar()
     {
         $this->parse(
             'FREQ=WEEKLY;BYDAY=MO;UNTIL=20090704T205959Z;INTERVAL=1',

--- a/tests/VObject/TimeZoneUtilTest.php
+++ b/tests/VObject/TimeZoneUtilTest.php
@@ -8,7 +8,7 @@ class TimeZoneUtilTest extends TestCase
 {
     public function setUp(): void
     {
-        // clearning the tz cache
+        // clearing the tz cache
         TimeZoneUtil::$map = null;
     }
 
@@ -82,7 +82,7 @@ HI;
         $this->assertEquals($ex->getName(), $tz->getName());
     }
 
-    public function testWetherMicrosoftIsStillInsane()
+    public function testWhetherMicrosoftIsStillInsane()
     {
         $vobj = <<<HI
 BEGIN:VCALENDAR


### PR DESCRIPTION
The latest php-cs-fixer finds some new things. Code changes were needed in https://github.com/sabre-io/dav/pull/1316 for `sabre/dav`. We might as well consistently make sure to use at least this version 2.17.1 in all repos so that we are doing consistent code-style checking.

It complains about:
- underscore `_` in method names. 
- use of `die()` (wants it to be `exit()`)
- blank lines in switch-case

1) adjust code to make php-cs-fixer happy
2) Update windowszones timezone data to 2020-12-13
3) Fix various typos