### PR TITLE
Verify 529

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
+        "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^0.12"
     },
     "suggest" : {

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -536,7 +536,7 @@ class RRuleIterator implements Iterator
                     foreach ($this->byWeekNo as $byWeekNo) {
                         foreach ($dayOffsets as $dayOffset) {
                             $date = clone $this->currentDate;
-                            $date->setISODate($currentYear, $byWeekNo, $dayOffset);
+                            $date = $date->setISODate($currentYear, $byWeekNo, $dayOffset);
 
                             if ($date > $this->currentDate) {
                                 $checkDates[] = $date;

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -350,6 +350,26 @@ END:VCALENDAR
         );
     }
 
+    public function testEventExpandYearly()
+    {
+        $input = 'BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:1a093f1012086078fdd3d9df5ff4d7d0
+DTSTART;TZID=UTC:20210203T130000
+DTEND;TZID=UTC:20210203T140000
+RRULE:FREQ=YEARLY;COUNT=7;WKST=MO;BYDAY=MO;BYWEEKNO=13,15,50
+END:VEVENT
+END:VCALENDAR
+';
+        $vcal = VObject\Reader::read($input);
+        $events = $vcal->expand(
+            new \DateTime('2021-01-01'),
+            new \DateTime('2023-01-01')
+        );
+
+        $this->assertCount(7, $events->VEVENT);
+    }
+
     public function testGetDocumentType()
     {
         $vcard = new VCalendar();

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -350,6 +350,13 @@ END:VCALENDAR
         );
     }
 
+    /**
+     * This test used to induce an infinite loop.
+     * The "medium" annotation means that phpunit will fail the
+     * test if it takes longer than a default of 10 seconds.
+     *
+     * @medium
+     */
     public function testEventExpandYearly()
     {
         $input = 'BEGIN:VCALENDAR

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -591,6 +591,19 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+	public function testYearlyByDayByWeekNo()
+	{
+		$this->parse(
+			'FREQ=YEARLY;COUNT=3;BYDAY=MO;BYWEEKNO=13,15,50',
+			'2021-01-01 00:00:00',
+			[
+				'2021-01-01 00:00:00',
+				'2021-03-29 00:00:00',
+				'2021-04-12 00:00:00',
+			]
+		);
+	}
+
     public function testFastForward()
     {
         // The idea is that we're fast-forwarding too far in the future, so

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -892,6 +892,13 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * This test can take some seconds to complete.
+     * The "large" annotation means phpunit will let it run for
+     * up to 60 seconds by default.
+     *
+     * @large
+     */
     public function testNeverEnding()
     {
         $this->parse(

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -591,18 +591,18 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-	public function testYearlyByDayByWeekNo()
-	{
-		$this->parse(
-			'FREQ=YEARLY;COUNT=3;BYDAY=MO;BYWEEKNO=13,15,50',
-			'2021-01-01 00:00:00',
-			[
-				'2021-01-01 00:00:00',
-				'2021-03-29 00:00:00',
-				'2021-04-12 00:00:00',
-			]
-		);
-	}
+    public function testYearlyByDayByWeekNo()
+    {
+        $this->parse(
+            'FREQ=YEARLY;COUNT=3;BYDAY=MO;BYWEEKNO=13,15,50',
+            '2021-01-01 00:00:00',
+            [
+                '2021-01-01 00:00:00',
+                '2021-03-29 00:00:00',
+                '2021-04-12 00:00:00',
+            ]
+        );
+    }
 
     public function testFastForward()
     {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -6,6 +6,9 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="true"
   beStrictAboutOutputDuringTests="true"
+  failOnRisky="true"
+  failOnWarning="true"
+  enforceTimeLimit="true"
   >
   <testsuites>
     <testsuite name="Sabre\VObject">


### PR DESCRIPTION
Commits 1,2,3 are the test code additions cherry-picked from PR #529 - with current `master` the test case `testEventExpandYearly` goes into an infinite loop. That demonstrates the problem.

Commit 4 adds annotations to 2 tests so that phpunit can fail them if/when they reach the execution time limit. That will make the fails manageable in CI, and when running locally. You do not have t wait until the end-of-time to get a result! See phpunit docs https://phpunit.readthedocs.io/en/9.5/risky-tests.html#test-execution-timeout

The CI should fail with a timeout of `testEventExpandYearly`

After that I will add the commit that fixes the bug, and CI should pass.