### PR TITLE
Make use of until parameter in nextMonthly function

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -466,13 +466,12 @@ class RRuleIterator implements Iterator
 
             // This goes to 0 because we need to start counting at the
             // beginning.
-	    $currentDayOfMonth = 0;
+            $currentDayOfMonth = 0;
 
-            // For some reason the "until" parameter was not being taken into
-	    // account, that's why the workaround of the 10000 year bug was
-	    // needed at all.
-            // Let's stop it before the "until" parameter date arrives.
-            if ($this->currentDate->getTimestamp() >= $this->until->getTimestamp()){
+            // For some reason the "until" parameter was not being used here,
+            // that's why the workaround of the 10000 year bug was needed at all
+            // let's stop it before the "until" parameter date
+            if ($this->currentDate->getTimestamp() >= $this->until->getTimestamp()) {
                 return;
             }
 
@@ -483,7 +482,7 @@ class RRuleIterator implements Iterator
 
                 return;
             }
-	}
+        }
 
         $this->currentDate = $this->currentDate->setDate(
             (int) $this->currentDate->format('Y'),
@@ -884,7 +883,7 @@ class RRuleIterator implements Iterator
             foreach ($this->byMonthDay as $monthDay) {
                 // Removing values that are out of range for this month
                 if ($monthDay > $startDate->format('t') ||
-                $monthDay < 0 - $startDate->format('t')) {
+                    $monthDay < 0 - $startDate->format('t')) {
                     continue;
                 }
                 if ($monthDay > 0) {
@@ -978,3 +977,4 @@ class RRuleIterator implements Iterator
         return $recurrenceMonths;
     }
 }
+

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -471,7 +471,7 @@ class RRuleIterator implements Iterator
             // For some reason the "until" parameter was not being used here,
             // that's why the workaround of the 10000 year bug was needed at all
             // let's stop it before the "until" parameter date
-            if ($this->currentDate->getTimestamp() >= $this->until->getTimestamp()) {
+            if ($this->until && $this->currentDate->getTimestamp() >= $this->until->getTimestamp()) {
                 return;
             }
 

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -977,4 +977,3 @@ class RRuleIterator implements Iterator
         return $recurrenceMonths;
     }
 }
-

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -466,7 +466,15 @@ class RRuleIterator implements Iterator
 
             // This goes to 0 because we need to start counting at the
             // beginning.
-            $currentDayOfMonth = 0;
+	    $currentDayOfMonth = 0;
+
+            // For some reason the "until" parameter was not being taken into
+	    // account, that's why the workaround of the 10000 year bug was
+	    // needed at all.
+            // Let's stop it before the "until" parameter date arrives.
+            if ($this->currentDate->getTimestamp() >= $this->until->getTimestamp()){
+                return;
+            }
 
             // To prevent running this forever (better: until we hit the max date of DateTimeImmutable) we simply
             // stop at 9999-12-31. Looks like the year 10000 problem is not solved in php ....
@@ -475,7 +483,7 @@ class RRuleIterator implements Iterator
 
                 return;
             }
-        }
+	}
 
         $this->currentDate = $this->currentDate->setDate(
             (int) $this->currentDate->format('Y'),

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -332,6 +332,22 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    public function testMonthlyByDayUntil()
+    {
+        $this->parse(
+            'FREQ=MONTHLY;INTERVAL=1;BYDAY=WE;WKST=WE;UNTIL=20210317T000000Z',
+            '2021-02-10 00:00:00',
+            [
+                '2021-02-10 00:00:00',
+                '2021-02-17 00:00:00',
+                '2021-02-24 00:00:00',
+                '2021-03-03 00:00:00',
+                '2021-03-10 00:00:00',
+                '2021-03-17 00:00:00',
+            ]
+        );
+    }
+
     public function testMonthlyByDayByMonthDay()
     {
         $this->parse(

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -348,6 +348,17 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    public function testMonthlyByDayUntilWithImpossibleNextOccurrence()
+    {
+        $this->parse(
+            'FREQ=MONTHLY;INTERVAL=1;BYDAY=2WE;BYMONTHDAY=2;WKST=WE;UNTIL=20210317T000000Z',
+            '2021-02-10 00:00:00',
+            [
+                '2021-02-10 00:00:00',
+            ]
+        );
+    }
+
     public function testMonthlyByDayByMonthDay()
     {
         $this->parse(


### PR DESCRIPTION
Hello there,

I've felt the need of this PR becauase of a buggy event:
FREQ=MONTHLY;
INTERVAL=1;
BYMONTHDAY=2;
BYDAY=2WE;
WKST=WE;
UNTIL=20211214T000000Z

The "Until" was not being taken into account, so it was falling into the 10000 year problem.