### PR TITLE
Reordering of the attendees should not be a signitifcant change (#540)

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -547,9 +547,13 @@ class Broker
                 // properties changed in the event, or simply if there's a
                 // difference in instances that the attendee is invited to.
 
+                $oldAttendeeInstances = array_keys($attendee['oldInstances']);
+                $newAttendeeInstances = array_keys($attendee['newInstances']);
+
                 $message->significantChange =
                     'REQUEST' === $attendee['forceSend'] ||
-                    array_keys($attendee['oldInstances']) != array_keys($attendee['newInstances']) ||
+                    count($oldAttendeeInstances) != count($newAttendeeInstances) ||
+                    count(array_diff($oldAttendeeInstances, $newAttendeeInstances)) > 0 ||
                     $oldEventInfo['significantChangeHash'] !== $eventInfo['significantChangeHash'];
 
                 foreach ($attendee['newInstances'] as $instanceId => $instanceInfo) {

--- a/tests/VObject/ITip/BrokerSignificantChangesTest.php
+++ b/tests/VObject/ITip/BrokerSignificantChangesTest.php
@@ -105,4 +105,46 @@ ICS;
 
         $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
     }
+
+    /**
+     * Check significant changes detection (no change).
+     * Reordering of the attendees should not be a signitifcant change (#540)
+     * https://github.com/sabre-io/vobject/issues/540.
+     */
+    public function testSignificantChangesAttendeesOrderNoChange()
+    {
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Ximian//NONSGML Evolution Calendar//EN
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20140813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY;BYDAY=MO
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=de:MAILTO:holger@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $new = str_replace('holger@fruux.com', 'dominik1@fruux.com', $old);
+        $new = str_replace('dominik@fruux.com', 'holger@fruux.com', $new);
+        $new = str_replace('dominik1@fruux.com', 'dominik@fruux.com', $new);
+        $expected = [];
+        $expected[] = ['significantChange' => false];
+        $expected[] = ['significantChange' => false];
+
+        $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
+    }
 }


### PR DESCRIPTION
https://github.com/sabre-io/vobject/issues/540

If a server (using sabre) receives a VEVENT update it will send mails to all attendees. Not for all modified events, but for events with a "significant change". The calculation of "signifcant change" is done by vobject.

I have trouble with to many "Invitation: ..."-Mails for events that has not been changed.

Investigating this I have seen:

- the events were modified by the client and sent to the server (eg. to save the acknowledgment of an alarm).
- the client has changed the order (not the attendees itself) of the attendees in the modified event
- vobject calculated a "significant change"
- the server sent the email

I think everything is correct, except, the reordering is not a significant change. Why the client desires to reorder the attendees? I don't know, but I think this should not be a significant change.