### PR TITLE
Reordering of vevent should not be a significant change (#542)

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -820,7 +820,10 @@ class Broker
         $instances = [];
         $exdate = [];
 
+        $significantChangeEventProperties = [];
+
         foreach ($calendar->VEVENT as $vevent) {
+            $eventSignificantChangeHash = '';
             $rrule = [];
 
             if (is_null($uid)) {
@@ -934,19 +937,26 @@ class Broker
                 if (isset($vevent->$prop)) {
                     $propertyValues = $vevent->select($prop);
 
-                    $significantChangeHash .= $prop.':';
+                    $eventSignificantChangeHash .= $prop.':';
 
                     if ('EXDATE' === $prop) {
-                        $significantChangeHash .= implode(',', $exdate).';';
+                        $eventSignificantChangeHash .= implode(',', $exdate).';';
                     } elseif ('RRULE' === $prop) {
-                        $significantChangeHash .= implode(',', $rrule).';';
+                        $eventSignificantChangeHash .= implode(',', $rrule).';';
                     } else {
                         foreach ($propertyValues as $val) {
-                            $significantChangeHash .= $val->getValue().';';
+                            $eventSignificantChangeHash .= $val->getValue().';';
                         }
                     }
                 }
             }
+            $significantChangeEventProperties[] = $eventSignificantChangeHash;
+        }
+
+        asort($significantChangeEventProperties);
+
+        foreach ($significantChangeEventProperties as $eventSignificantChangeHash) {
+            $significantChangeHash .= $eventSignificantChangeHash;
         }
         $significantChangeHash = md5($significantChangeHash);
 

--- a/tests/VObject/ITip/BrokerSignificantChangesTest.php
+++ b/tests/VObject/ITip/BrokerSignificantChangesTest.php
@@ -108,7 +108,7 @@ ICS;
 
     /**
      * Check significant changes detection (no change).
-     * Reordering of the attendees should not be a signitifcant change (#540)
+     * Reordering of the attendees should not be a significant change (#540)
      * https://github.com/sabre-io/vobject/issues/540.
      */
     public function testSignificantChangesAttendeesOrderNoChange()
@@ -144,6 +144,72 @@ ICS;
         $expected = [];
         $expected[] = ['significantChange' => false];
         $expected[] = ['significantChange' => false];
+
+        $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
+    }
+
+    /**
+     * Check significant changes detection (no change).
+     * Reordering of vevent in a recurring event with exceptions should
+     * not be a significant change
+     * https://github.com/sabre-io/vobject/issues/542.
+     */
+    public function testSignificantChangesVeventOrderNoChange()
+    {
+        $vevent1 = <<<ICS
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20140813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY;BYDAY=MO
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+ICS;
+        // This event is slightly different. DTSTAMP is in 2021
+        $vevent2 = <<<ICS
+BEGIN:VEVENT
+UID:20140813T153116Z-12176-1000-1065-6@johnny-lubuntu
+DTSTAMP:20210813T142829Z
+DTSTART;TZID=America/Toronto:20140815T110000
+SEQUENCE:2
+SUMMARY:Evo makes a Meeting
+LOCATION:fruux HQ
+CLASS:PUBLIC
+RRULE:FREQ=WEEKLY;BYDAY=MO
+ORGANIZER:MAILTO:martin@fruux.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;LANGUAGE=en:MAILTO:dominik@fruux.com
+CREATED:20140813T153211Z
+LAST-MODIFIED:20140813T155353Z
+END:VEVENT
+ICS;
+
+        $head = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Ximian//NONSGML Evolution Calendar//EN
+ICS;
+
+        $old = $head;
+        $old .= "\n".$vevent1;
+        $old .= "\n".$vevent2;
+        $old .= "\nEND:VCALENDAR";
+
+        $new = $head;
+        $new .= "\n".$vevent1;
+        $new .= "\n".$vevent2;
+        $new .= "\nEND:VCALENDAR";
+
+        $expected = [['significantChange' => false]];
 
         $this->parse($old, $new, $expected, 'mailto:martin@fruux.com');
     }


### PR DESCRIPTION
Related to #540

If a server (using sabre) receives a VEVENT update it will send mails to all attendees. Not for all modified events, but for events with a "significant change". The calculation of "signifcant change" is done by vobject.

I have trouble with to many "Invitation: ..."-Mails for events that has not been changed.

Investigating this I have seen:

- the events were modified by the client and sent to the server (eg. to save the acknowledgment of an alarm).
-  the client has changed the order (not the vevents itself) of the venets in the modified event
-  vobject calculated a "significant change" (by SignificantChangeHash)
-  the server sent the email

I think everything is correct, except, the reordering is not a significant change. Why the client desires to reorder the vevents? I don't know, but I think this should not be a significant change.