### PR TITLE
sync ci.yml to match other repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP, with Composer and Extensions
+      - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
@@ -31,11 +31,11 @@ jobs:
           coverage: ${{ matrix.coverage }}
           tools: composer
 
-      - name: Get Composer Cache Directory
+      - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - name: Cache Composer Dependencies
+      - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install Composer Dependencies
+      - name: Install composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
@@ -55,7 +55,7 @@ jobs:
         if: matrix.code-analysis == 'yes'
         run: composer phpstan
 
-      - name: Test with PHPUnit
+      - name: Test with phpunit
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
 
       - name: Code Coverage


### PR DESCRIPTION
Just a few name changes so that this matches with https://github.com/sabre-io/http and we can copy-paste to each repo without constantly wondering why the name text is slightly different everywhere.