### PR TITLE
Changes that should have happened for 4.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+4.3.6 (2021-11-04)
+------------------
+
+* #544 Fix deprecated usages and return types on PHP 8.1 (@cedric-anne)
+
 4.3.5 (2021-02-12)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '4.3.5';
+    const VERSION = '4.3.6';
 }


### PR DESCRIPTION
I should have done these things before releasing 4.3.6:

1) bump the VERSION constant

2) add the changelog details to CHANGELOG.md

This PR commits the changes (but too late for 4.3.6). There are some other PRs to be finished, so I can do a 4.3.7 release very soon and do the process better for that.