### PR TITLE
Handle Vobjects without closing tag

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -167,7 +167,11 @@ class MimeDir extends Parser
 
         while (true) {
             // Reading until we hit END:
-            $line = $this->readLine();
+            try {
+                $line = $this->readLine();
+            } catch (EofException $oEx) {
+                $line = 'END:'.$this->root->name;
+            }
             if ('END:' === strtoupper(substr($line, 0, 4))) {
                 break;
             }

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -114,11 +114,16 @@ class ReaderTest extends TestCase
         $this->assertEquals('20110529', $result->getValue());
     }
 
-    public function testReadBrokenLine()
+    public function testReadMissingEnd()
     {
-        $this->expectException(ParseException::class);
-        $data = "BEGIN:VCALENDAR\r\nPROPNAME;propValue";
+        $data = "BEGIN:VCALENDAR\r\nPROPNAME:propValue";
         $result = Reader::read($data);
+        $this->assertInstanceOf(Component::class, $result);
+        $this->assertEquals('VCALENDAR', $result->name);
+        $this->assertEquals(1, count($result->children()));
+        $this->assertInstanceOf(Property::class, $result->children()[0]);
+        $this->assertEquals('PROPNAME', $result->children()[0]->name);
+        $this->assertEquals('propValue', $result->children()[0]->getValue());
     }
 
     public function testReadPropertyInComponent()


### PR DESCRIPTION
There are cases when objects do not have closing tags (for example, END: VCALENDAR), this fix solves this issue.