### PR TITLE
Type property parameters via phpdoc

### DIFF
--- a/lib/Property.php
+++ b/lib/Property.php
@@ -37,7 +37,7 @@ abstract class Property extends Node
     /**
      * List of parameters.
      *
-     * @var array
+     * @var Parameter[]
      */
     public $parameters = [];
 
@@ -64,7 +64,7 @@ abstract class Property extends Node
      * @param Component         $root       The root document
      * @param string            $name
      * @param string|array|null $value
-     * @param array             $parameters List of parameters
+     * @param array             $parameters List of parameter values
      * @param string            $group      The vcard property group
      */
     public function __construct(Component $root, $name, $value = null, array $parameters = [], $group = null)
@@ -178,7 +178,7 @@ abstract class Property extends Node
     /**
      * Returns an iterable list of children.
      *
-     * @return array
+     * @return Parameter[]
      */
     public function parameters()
     {

--- a/lib/Property/Uri.php
+++ b/lib/Property/Uri.php
@@ -40,7 +40,7 @@ class Uri extends Text
     /**
      * Returns an iterable list of children.
      *
-     * @return array
+     * @return Parameter[]
      */
     public function parameters()
     {


### PR DESCRIPTION
And update the property constructor to better reflect that the
$parameters are an array of values, not instances of the parameter
class.

I suppose this can be seen as part of https://github.com/sabre-io/dav/issues/1368.

Context: I converted some Nextcloud code into strict code and the section with properties/parameters was not understood by PHPStorm until I made these changes.