### PR TITLE
Fix infinite loop caused by yearly with bySetPos

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -658,6 +658,14 @@ class RRuleIterator implements Iterator
                     (int) $currentMonth,
                     (int) $currentDayOfMonth
                 );
+
+                // To prevent running this forever (better: until we hit the max date of DateTimeImmutable) we simply
+                // stop at 9999-12-31. Looks like the year 10000 problem is not solved in php ....
+                if ($this->currentDate->getTimestamp() > 253402300799) {
+                    $this->currentDate = null;
+
+                    return;
+                }
             }
 
             // If we made it here, it means we got a valid occurrence

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -825,6 +825,17 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    public function testYearlyBySetPosLoop()
+    {
+        $this->parse(
+            'FREQ=YEARLY;BYMONTH=5;BYSETPOS=3;BYMONTHDAY=3',
+            '2022-03-03 15:45:00',
+            [
+            ],
+            '2022-05-01'
+        );
+    }
+
     /**
      * Something, somewhere produced an ics with an interval set to 0. Because
      * this means we increase the current day (or week, month) by 0, this also


### PR DESCRIPTION
Consider the rrule:
`FREQ=YEARLY;BYMONTH=5;BYSETPOS=3;BYMONTHDAY=3`

It will not generate any occurrence, but the `RRuleIterator` will stuck in the infinite loop