### PR TITLE
Add NICKNAME fallback for VCards without FNs

### DIFF
--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -292,7 +292,7 @@ class VCard extends VObject\Document
                     $repaired = true;
                 
                 // Otherwise, the NICKNAME property may work
-                elseif (isset($this->NICKNAME)) {
+                } elseif (isset($this->NICKNAME)) {
                     $this->FN = (string) $this->NICKNAME;
                     $repaired = true;
                     

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -290,7 +290,12 @@ class VCard extends VObject\Document
                 } elseif (isset($this->ORG)) {
                     $this->FN = (string) $this->ORG;
                     $repaired = true;
-
+                
+                // Otherwise, the NICKNAME property may work
+                elseif (isset($this->NICKNAME)) {
+                    $this->FN = (string) $this->NICKNAME;
+                    $repaired = true;
+                    
                 // Otherwise, the EMAIL property may work
                 } elseif (isset($this->EMAIL)) {
                     $this->FN = (string) $this->EMAIL;

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -92,6 +92,14 @@ class VCardTest extends TestCase
             ],
             "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:foo\r\nORG:Acme Co.\r\nFN:Acme Co.\r\nEND:VCARD\r\n",
         ];
+        // No FN, NICKNAME fallback
+        $tests[] = [
+            "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:foo\r\NICKNAME:JohnDoe\r\nEND:VCARD\r\n",
+            [
+                'The FN property must appear in the VCARD component exactly 1 time',
+            ],
+            "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:foo\r\nNICKNAME:JohnDoe\r\nFN:JohnDoe\r\nEND:VCARD\r\n",
+        ];
         // No FN, EMAIL fallback
         $tests[] = [
             "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:foo\r\nEMAIL:1@example.org\r\nEND:VCARD\r\n",


### PR DESCRIPTION
This is a rare yet possible case (I stumbled upon such VCards in my own Google Account storage) where a NICKNAME is defined on a VCard but no FN. Importing such contacts into Nextcloud (using Sabre/VObject) is a bit of a pain, this attempts to solve it.