### PR TITLE
Component/select: Before uppercasing $child->group, make sure it isn't null

### DIFF
--- a/lib/Component.php
+++ b/lib/Component.php
@@ -249,7 +249,7 @@ class Component extends Node
         $result = [];
         foreach ($this->children as $childGroup) {
             foreach ($childGroup as $child) {
-                if ($child instanceof Property && strtoupper($child->group) === $group) {
+                if ($child instanceof Property && $child->group && strtoupper($child->group) === $group) {
                     $result[] = $child;
                 }
             }


### PR DESCRIPTION
I recently set up Baïkal, and it works wonderfully with most clients I let at it. However, I ran into an issue when I tried using InfCloud pointed at it: my address book didn't display, because Baïkal returned a HTTP 500 to some request InfCloud was making.

I dug into the logs, and I found that the issue is this backtrace:

```
today at 1:58:13 AM2022/05/11 23:58:13 [error] 23#23: *1387 FastCGI sent in stderr: "PHP message: ErrorException: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/baikal/vendor/sabre/vobject/lib/Component.php:252
today at 1:58:13 AMStack trace:
today at 1:58:13 AM#0 [internal function]: Baikal\Framework::exception_error_handler()
today at 1:58:13 AM#1 /var/www/baikal/vendor/sabre/vobject/lib/Component.php(252): strtoupper()
today at 1:58:13 AM#2 /var/www/baikal/vendor/sabre/vobject/lib/VCardConverter.php(119): Sabre\VObject\Component->select()
today at 1:58:13 AM#3 /var/www/baikal/vendor/sabre/vobject/lib/VCardConverter.php(55): Sabre\VObject\VCardConverter->convertProperty()
today at 1:58:13 AM#4 /var/www/baikal/vendor/sabre/vobject/lib/Component/VCard.php(189): Sabre\VObject\VCardConverter->convert()
today at 1:58:13 AM#5 /var/www/baikal/vendor/sabre/dav/lib/CardDAV/Plugin.php(829): Sabre\VObject\Component\VCard->convert()
today at 1:58:13 AM#6 /var/www/baikal/vendor/sabre/dav/lib/CardDAV/Plugin.php(244): Sabre\CardDAV\Plugin->convertVCard()
today at 1:58:13 AM#7 /var/www/baikal/vendor/sabre/dav/lib/CardDAV/Plugin.php(189): Sabre\CardDAV\Plugin->addressbookMultiGetReport()
```

Naturally, I went looking, as this seemed easy to fix, or at least work around. I have no idea what request InfCloud is sending, mind you. I looked at it, it was a lot of XML, I ran away. So I looked at the Baïkal side instead, tracked down the place the error was coming from, and did as this patch does: before calling `strtoupper($child->group)`, I added another check to see if `$child->group` is non-null.

Now I have my address book shown via InfCloud too, and everything else appears to work as well.

I'm not sure if its the right fix, but it gets the job done, so I figured I'll share.