### PR TITLE
Ignore multiple same parameter-values

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -378,6 +378,9 @@ class MimeDir extends Parser
                     $property['parameters'][$lastParam] = $value;
                 } elseif (is_array($property['parameters'][$lastParam])) {
                     $property['parameters'][$lastParam][] = $value;
+                } elseif ($property['parameters'][$lastParam] === $value) {
+                    // When the current value of the parameter is the same as the
+                    // new one, then we can leave the current parameter as it is.
                 } else {
                     $property['parameters'][$lastParam] = [
                         $property['parameters'][$lastParam],

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -162,7 +162,7 @@ EOF;
 
         $mimeDir = new MimeDir();
         $vcard = $mimeDir->parse($card);
-        // we can do a simple assertion here. As long as we don't get an exception, everything is thing
+        // we can do a simple assertion here. As long as we don't get an exception, everything is fine
         $this->assertEquals('20220612', $vcard->VEVENT->DTSTART->getValue());
     }
 }

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -145,4 +145,24 @@ VCF;
         $this->assertEquals('Euro', $vcard->FN->getValue());
         $this->assertEquals('Test2', $vcard->N->getValue());
     }
+
+    public function testParsingTwiceSameContent()
+    {
+        $card = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:PRODID
+BEGIN:VEVENT
+DTSTAMP;TZID=Europe/Busingen:20220712T172312
+UID:UID
+DTSTART;VALUE=DATE;VALUE=DATE;VALUE=DATE:20220612
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+        $mimeDir = new MimeDir();
+        $vcard = $mimeDir->parse($card);
+        // we can do a simple assertion here. As long as we don't get an exception, everything is thing
+        $this->assertEquals('20220612', $vcard->VEVENT->DTSTART->getValue());
+    }
 }


### PR DESCRIPTION
Sometimes it seems like parameters can be added multiple times with the same value. Besides not making any sense (and partially being not allowed in the first place) this will also possibly break the further process of parsing an icalendar file.

This modification adds a shortcut when the last parameter-value and the current parameter value are exactly the same. In that case the new value is ignored and only the old value will be used.

The use-case - as documented in the test - is that there seem to be icalendar files that contain the following content:

    DTSTART;VALUE=DATE;VALUE=DATE:20220612

While that seems to violate the RFC it is not seen as a violation in the icalendar validator at https://icalendar.org/validator.html and as it can also be imported by other calendaring systems it looks like this should at least not break the parser.