### PR TITLE
Fix code-style

### DIFF
--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -169,6 +169,7 @@ EOF;
 
     /**
      * @covers \Sabre\VObject\Parser\MimeDir::readProperty
+     *
      * @dataProvider provideBrokenVCalendar
      */
     public function testBrokenMultilineContentDoesNotBreakImportWhenSetToIgnoreBrokenLines(string $vcalendar): void
@@ -180,6 +181,7 @@ EOF;
 
     /**
      * @covers \Sabre\VObject\Parser\MimeDir::readProperty
+     *
      * @dataProvider provideBrokenVCalendar
      *
      * @param string $vcalendar

--- a/tests/VObject/Recur/EventIterator/MainTest.php
+++ b/tests/VObject/Recur/EventIterator/MainTest.php
@@ -759,6 +759,7 @@ class MainTest extends TestCase
      * after 1 second. Would be good to optimize later.
      *
      * @depends testValues
+     *
      * @medium
      */
     public function testMonthlyByDay(): void


### PR DESCRIPTION
It looks like a new version of php-cs-fixer likes having a bit more spacing in PHPdoc blocks.

Apply these changes so that CI will be green.