### PR TITLE
Add PHP 8.2 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
         coverage: ['pcov']
         code-analysis: ['no']
         include:


### PR DESCRIPTION
PHP 8.2 is available now in GitHub, and it passes.