### PR TITLE
Remove utf8_encode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         coverage: ['pcov']
         code-analysis: ['no']
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+4.5.1 (2022-10-09)
+------------------
+
+* #597: Remove utf8_encode to easily support PHP 8.2 (@phil-davis)
+
 4.5.0 (2022-08-17)
 ------------------
 

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -464,10 +464,8 @@ class MimeDir extends Parser
             switch (strtolower($charset)) {
                 case 'utf-8':
                     break;
-                case 'iso-8859-1':
-                    $property['value'] = utf8_encode($property['value']);
-                    break;
                 case 'windows-1252':
+                case 'iso-8859-1':
                     $property['value'] = mb_convert_encoding($property['value'], 'UTF-8', $charset);
                     break;
                 default:

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '4.5.0';
+    const VERSION = '4.5.1';
 }

--- a/tests/VObject/StringUtilTest.php
+++ b/tests/VObject/StringUtilTest.php
@@ -29,9 +29,10 @@ class StringUtilTest extends TestCase
 
     public function testConvertToUTF8nonUTF8()
     {
-        $string = StringUtil::convertToUTF8(chr(0xbf));
+        // 0xBF is an ASCII upside-down question mark
+        $string = StringUtil::convertToUTF8(chr(0xBF));
 
-        $this->assertEquals(utf8_encode(chr(0xbf)), $string);
+        $this->assertEquals(mb_convert_encoding(chr(0xBF), 'UTF-8', 'ISO-8859-1'), $string);
     }
 
     public function testConvertToUTF8IsUTF8()


### PR DESCRIPTION
Apply "Remove utf8_encode" to 4.5 so that we can make a simple 4.5.1 release, without all the arg/return-type changes that are in progress on master.

And add PHP 8.2 to the CI here, to demonstrate that it passes.