### PR TITLE
Prepare 4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+4.5.1 (2022-10-09)
+------------------
+
+* #597: Remove utf8_encode to easily support PHP 8.2 (@phil-davis)
+
 4.5.0 (2022-08-17)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.5.0';
+    public const VERSION = '4.5.1';
 }


### PR DESCRIPTION
4.5.1 was already released on the 4.5 branch. The actual code fix is already in the master branch (as well as the 4t into master=.5 branch). Only the version change and changelog need to be brought into master.