### PR TITLE
Fix unescaping of URIs in VCard4 and mime type of images in converter

### DIFF
--- a/lib/VCardConverter.php
+++ b/lib/VCardConverter.php
@@ -180,6 +180,10 @@ class VCardConverter
                     if ('GROUP' === strtoupper($property->getValue())) {
                         $newProperty = $output->createProperty('KIND', 'GROUP');
                     }
+                    if ('INDIVIDUAL' === strtoupper($property->getValue())) {
+                        // Individual is implicit, so we skip it.
+                        return;
+                    }
                     break;
                 case 'X-ADDRESSBOOKSERVER-MEMBER':
                     $newProperty = $output->createProperty('MEMBER', $property->getValue());

--- a/lib/VCardConverter.php
+++ b/lib/VCardConverter.php
@@ -336,7 +336,7 @@ class VCardConverter
         unset($value);
 
         $newProperty['ENCODING'] = 'b';
-        switch ($mimeType) {
+        switch (strtolower($mimeType)) {
             case 'image/jpeg':
                 $newProperty['TYPE'] = 'JPEG';
                 break;

--- a/tests/VObject/Property/UriTest.php
+++ b/tests/VObject/Property/UriTest.php
@@ -23,4 +23,29 @@ ICS;
         $output = Reader::read($input)->serialize();
         $this->assertStringContainsString('URL;VALUE=URI:http://example.org/', $output);
     }
+
+    public function testUriUnescapedProperly(): void
+    {
+        // The colon should normally not be escaped in URL, but Google Contacts does it and
+        // vobject contains a workaround for it
+        $input = <<<VCF
+BEGIN:VCARD
+VERSION:4.0
+PRODID:-//Thunderbird.net/NONSGML Thunderbird CardBook V83.6//EN-GB
+UID:5cdac90f-cb4c-4c1c-ad66-fe8591bdf3a2
+FN:vCard 4 Contact with image
+EMAIL:bbb@example.org
+REV:20221222T213003Z
+PHOTO:data:image/JPEG\;base64\,/9j/4AAQSkZJRgABAQAAYABgAAD/2wBDAAgGBgcGBQgHB
+ wcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/
+ wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAAAv/EABQQAQAAAAAAAAAAAAAAAAAAAAD
+ /2gAIAQEAAD8AL//Z
+item1.URL:http\://www.example.com/hello?world
+item1.X-ABLabel:
+END:VCARD
+VCF;
+        $output = Reader::read($input);
+        $this->assertSame('http://www.example.com/hello?world', (string) $output->URL);
+        $this->assertSame('data:image/JPEG;base64,/9j/4AAQSkZJRgABAQAAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAAAv/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AL//Z', (string) $output->PHOTO);
+    }
 }

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -409,7 +409,14 @@ OUT;
             $vcard
         );
 
-        $input = $output;
+        $input = <<<IN
+BEGIN:VCARD
+VERSION:3.0
+X-ADDRESSBOOKSERVER-KIND:INDIVIDUAL
+END:VCARD
+
+IN;
+
         $output = <<<OUT
 BEGIN:VCARD
 VERSION:4.0

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -38,9 +38,9 @@ FN:Steve
 TEL;PREF=1;TYPE=HOME:+1 555 666 777
 ITEM1.TEL:+1 444 555 666
 ITEM1.X-ABLABEL:CustomLabel
-PHOTO;TYPE=HOME:data:image/jpeg;base64,Zm9v
-PHOTO:data:image/gif;base64,Zm9v
-PHOTO;X-PARAM=FOO:data:image/png;base64,Zm9v
+PHOTO;TYPE=HOME:data:image/jpeg;base64\\,Zm9v
+PHOTO:data:image/gif;base64\\,Zm9v
+PHOTO;X-PARAM=FOO:data:image/png;base64\\,Zm9v
 PHOTO:http://example.org/foo.png
 KIND:ORG
 END:VCARD
@@ -66,9 +66,9 @@ BEGIN:VCARD
 VERSION:4.0
 FN:Steve
 TEL;PREF=1;TYPE=HOME:+1 555 666 777
-PHOTO:data:image/jpeg;base64,Zm9v
-PHOTO:data:image/gif;base64,Zm9v
-PHOTO;X-PARAM=FOO:data:image/png;base64,Zm9v
+PHOTO:data:image/jpeg;base64\\,Zm9v
+PHOTO:data:image/gif;base64\\,Zm9v
+PHOTO;X-PARAM=FOO:data:image/png;base64\\,Zm9v
 PHOTO:http://example.org/foo.png
 END:VCARD
 
@@ -79,9 +79,9 @@ BEGIN:VCARD
 VERSION:4.0
 FN:Steve
 TEL;PREF=1;TYPE=HOME:+1 555 666 777
-PHOTO:data:image/jpeg;base64,Zm9v
-PHOTO:data:image/gif;base64,Zm9v
-PHOTO;X-PARAM=FOO:data:image/png;base64,Zm9v
+PHOTO:data:image/jpeg;base64\\,Zm9v
+PHOTO:data:image/gif;base64\\,Zm9v
+PHOTO;X-PARAM=FOO:data:image/png;base64\\,Zm9v
 PHOTO:http://example.org/foo.png
 END:VCARD
 
@@ -193,9 +193,9 @@ VERSION:4.0
 PRODID:foo
 FN:Steve
 TEL;PREF=1;TYPE=HOME:+1 555 666 777
-PHOTO:data:image/jpeg;base64,Zm9v
-PHOTO:data:image/gif,foo
-PHOTO;X-PARAM=FOO:data:image/png;base64,Zm9v
+PHOTO:data:image/JPEG\\;base64\\,Zm9v
+PHOTO:data:image/gif\\,foo
+PHOTO;X-PARAM=FOO:data:image/png;base64\\,Zm9v
 PHOTO:http://example.org/foo.png
 KIND:ORG
 END:VCARD


### PR DESCRIPTION
This PR fixes two issues encountered on a V4 VCard.

1. RFC6350 allows escaping of semicolons in property values, but vobject did not unescape them in input. data URIs used for inline images in v4 VCard contain both semicolon and comma. When the semicolon is escaped (which is optional for the producer of the VCard), it must be unescaped by the consumer or the resulting URI will still contain the backslash and be malformed.
2. Mime types are case insensitive (RFC2045). In the vcard converter in conversion from v4, the mime type is checked in a case sensitive manner and would thus fail to convert the mime type if it is not lowercase in the input. Changed the handling to treat this case-insensitive.

Tests adapted / extended accordingly.