### PR TITLE
Support sabre/xml v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php"          : "^7.4 || ^8.0",
         "ext-mbstring" : "*",
         "ext-json"     : "*",
-        "sabre/xml"    : "^3.0"
+        "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "^3.10.0",


### PR DESCRIPTION
I would like to use sabre/vobject together with latest sabre/xml v4.
Latest vobject release still uses sabre/xml v2.