### PR TITLE
Adjust code style to meet current php-cs-fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
+          update: false
           extensions: mbstring, dom, fileinfo, mysql, redis, opcache
           coverage: ${{ matrix.coverage }}
           tools: composer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1.13', '8.2.0']
         coverage: ['pcov']
         code-analysis: ['no']
         include:


### PR DESCRIPTION
php-cs-fixer is reporting these. I guess there has been a newer php-cs-fixer version released that is different.

It wants "root" classes and functions to use the leading `\` - `\InvalidArgumentException` `\substr` 