### PR TITLE
chore: fix ci deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             code-analysis: 'yes'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
@@ -33,10 +33,10 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
@@ -59,5 +59,5 @@ jobs:
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: matrix.coverage != 'none'

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -2,7 +2,6 @@
 
 namespace Sabre\VObject;
 
-use ReturnTypeWillChange;
 use Sabre\VObject;
 use Sabre\Xml;
 
@@ -324,7 +323,7 @@ class Component extends Node
      * This method returns an array, with the representation as it should be
      * encoded in JSON. This is used to create jCard or jCal documents.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         $components = [];

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -626,7 +626,7 @@ class MimeDir extends Parser
 
                             // @codeCoverageIgnoreStart
                     }
-                // @codeCoverageIgnoreEnd
+                    // @codeCoverageIgnoreEnd
                 },
                 $input
             );


### PR DESCRIPTION
Will fix warnings in ci
https://github.com/sabre-io/vobject/actions/runs/3986493156

checkout@v3
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

set-output
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Codecov (needs testing)
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1