### PR TITLE
Bump require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.10.0",
-        "phpunit/phpunit" : "^9.0",
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
-        "phpstan/phpstan": "^1.8"
+        "phpstan/phpstan": "^1.9"
     },
     "suggest" : {
         "hoa/bench"       : "If you would like to run the benchmark scripts"


### PR DESCRIPTION
I really just want to check that all of CI still passes (there have been minor version releases of the CI tools phpunit, phpstan and php-cs-fixer recently).

This PR updates the minor versions recorded in `composer.json`. That does not do anything exciting, but maybe it helps in the future that we know what minor version of each tool was known to work.