### PR TITLE
validate repair component should not deduplicate properties when properties must appear exactly once

### DIFF
--- a/lib/Component.php
+++ b/lib/Component.php
@@ -569,6 +569,9 @@ class Component extends Node
                     if (!isset($propertyCounters[$propName]) || 1 !== $propertyCounters[$propName]) {
                         $repaired = false;
                         if ($options & self::REPAIR && isset($defaults[$propName])) {
+                            if (isset($propertyCounters[$propName]) && 1 < $propertyCounters[$propName]) {
+                                $this->remove($propName);
+                            }
                             $this->add($propName, $defaults[$propName]);
                             $repaired = true;
                         }

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -482,6 +482,22 @@ class ComponentTest extends TestCase
         self::assertEquals('yow', $component->BAR->getValue());
     }
 
+    public function testValidateRepairShouldNotDeduplicatePropertiesWhenPropertiesMustAppearExactlyOnce(): void
+    {
+        $vcard = new Component\VCard();
+
+        $component = new FakeComponent($vcard, 'Hi', []);
+        $component->add('BAZ', 'BAZ');
+        $component->add('BAR', 'BAR');
+        $component->add('BAR', 'BAR');
+
+        $messages = $component->validate(Component::REPAIR);
+
+        self::assertCount(1, $messages);
+        self::assertCount(1, $component->BAR);
+        self::assertEquals('yow', $component->BAR->getValue());
+    }
+
     public function testValidateRepairShouldNotDeduplicatePropertiesWhenValuesDiffer(): void
     {
         $vcard = new Component\VCard();


### PR DESCRIPTION
The validate function with repair mode add automatically a property when the property must appear exactly once... like UID in VEVENT or VCARD.

A VCARD like this (with 2 UID for example) :
```
BEGIN:VCARD
VERSION:3.0
UID:a73404dd-7534-4151-a949-49711bef8422
UID:sabre-vobject-39afbdfc-47cf-489e-a1a3-6a8e6cc6b4f6
FN:Paul Martin
N:Martin;Paul;;;
END:VCARD
```

After a validate in repair mode, this VCARD looks like :  
```
BEGIN:VCARD
VERSION:3.0
UID:a73404dd-7534-4151-a949-49711bef8422
UID:sabre-vobject-39afbdfc-47cf-489e-a1a3-6a8e6cc6b4f6
UID:sabre-vobject-101f5d63-572f-44c6-90e5-ef6cb4bf385d
...
FN:Paul Martin
N:Martin;Paul;;;
END:VCARD
```

This can be very problematic. The test is not strict enough : 
`1 !== $propertyCounters[$propName]`

So we need to remove the old parameters when the number of properties is greater than 1. In fact, UID is a property which must appear exactly once.

Thanks.