### PR TITLE
Add new exchangetimezone 'Amsterdam, Berlin, Bern, Rom, Stockholm, Wien'

### DIFF
--- a/lib/timezonedata/exchangezones.php
+++ b/lib/timezonedata/exchangezones.php
@@ -17,6 +17,7 @@ return [
     'Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London' => 'Europe/Lisbon',
     'Greenwich Mean Time; Dublin, Edinburgh, London' => 'Europe/London',
     'Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna' => 'Europe/Berlin',
+    'Amsterdam, Berlin, Bern, Rom, Stockholm, Wien' => 'Europe/Berlin',
     'Belgrade, Pozsony, Budapest, Ljubljana, Prague' => 'Europe/Prague',
     'Brussels, Copenhagen, Madrid, Paris' => 'Europe/Paris',
     'Paris, Madrid, Brussels, Copenhagen' => 'Europe/Paris',


### PR DESCRIPTION
Add new timezone in lib/timezonedata/exchangezones.php:

'Amsterdam, Berlin, Bern, Rom, Stockholm, Wien' => 'Europe/Berlin', 

Example ICS-File:

BEGIN:VCALENDAR
METHOD:PUBLISH
PRODID:Microsoft Exchange Server 2010
VERSION:2.0
X-WR-CALNAME:***
BEGIN:VTIMEZONE
TZID:(UTC+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien
BEGIN:STANDARD
DTSTART:16010101T030000
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=10
END:STANDARD
BEGIN:DAYLIGHT
DTSTART:16010101T020000
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=3
END:DAYLIGHT
END:VTIMEZONE
BEGIN:VEVENT
.....