### PR TITLE
docs: fix type definition for oldCalendar

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -156,9 +156,9 @@ class Broker
      * people. If the user was an attendee, we need to make sure that the
      * organizer gets the 'declined' message.
      *
-     * @param VCalendar|string $calendar
-     * @param string|array     $userHref
-     * @param VCalendar|string $oldCalendar
+     * @param VCalendar|string      $calendar
+     * @param string|array          $userHref
+     * @param VCalendar|string|null $oldCalendar
      *
      * @return array
      */


### PR DESCRIPTION
The type definition for oldCalendar is fixed on master.

I would be happy about a back port for 4.5 to reduce the false-positive warnings by static code analysis. 