### PR TITLE
chore: use php-cs-fixer 3.49

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.38",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^1.10"


### PR DESCRIPTION
Recent php-cs-fixer minor releases suggest some new things.
For example, see PR https://github.com/sabre-io/xml/pull/271

It passes here in https://github.com/sabre-io/vobject so no code needs to be touched, but I may as well bump the required php-cs-fixer version to match with other repos.