### PR TITLE
chore: bump php-cs-fixer requirement to 3.54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.51",
+        "friendsofphp/php-cs-fixer": "^3.54",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^1.10"


### PR DESCRIPTION
After PR #644 adjusted the code indent, we need to use at least php-cs-fixer 3.54

May as well record that in `composer.json` - I forgot to do that yesterday.