### PR TITLE
ITip\Broker: handle timezones in replies to exception events

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -333,6 +333,9 @@ class Broker
 
         // Finding all the instances the attendee replied to.
         foreach ($itipMessage->message->VEVENT as $vevent) {
+            // Use the Unix timestamp returned by getTimestamp as a unique identifier for the recurrence.
+            // The Unix timestamp will be the same for an event, even if the reply from the attendee
+            // used a different format/timezone to express the event date-time.
             $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             $attendee = $vevent->ATTENDEE;
             $instances[$recurId] = $attendee['PARTSTAT']->getValue();
@@ -346,6 +349,7 @@ class Broker
         // all the instances where we have a reply for.
         $masterObject = null;
         foreach ($existingObject->VEVENT as $vevent) {
+            // Use the Unix timestamp returned by getTimestamp as a unique identifier for the recurrence.
             $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             if ('master' === $recurId) {
                 $masterObject = $vevent;
@@ -393,6 +397,9 @@ class Broker
                 $newObject = $recurrenceIterator->getEventObject();
                 $recurrenceIterator->next();
 
+                // Compare the Unix timestamp returned by getTimestamp with the previously calculated timestamp.
+                // If they are the same, then this is a matching recurrence, even though its date-time may have
+                // been expressed in a different format/timezone.
                 if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() === $recurId) {
                     $found = true;
                 }

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -333,7 +333,7 @@ class Broker
 
         // Finding all the instances the attendee replied to.
         foreach ($itipMessage->message->VEVENT as $vevent) {
-            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getValue() : 'master';
+            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             $attendee = $vevent->ATTENDEE;
             $instances[$recurId] = $attendee['PARTSTAT']->getValue();
             if (isset($vevent->{'REQUEST-STATUS'})) {
@@ -346,7 +346,7 @@ class Broker
         // all the instances where we have a reply for.
         $masterObject = null;
         foreach ($existingObject->VEVENT as $vevent) {
-            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getValue() : 'master';
+            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             if ('master' === $recurId) {
                 $masterObject = $vevent;
             }
@@ -393,7 +393,7 @@ class Broker
                 $newObject = $recurrenceIterator->getEventObject();
                 $recurrenceIterator->next();
 
-                if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getValue() === $recurId) {
+                if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() === $recurId) {
                     $found = true;
                 }
                 --$iterations;

--- a/tests/VObject/ITip/BrokerProcessReplyTest.php
+++ b/tests/VObject/ITip/BrokerProcessReplyTest.php
@@ -253,6 +253,75 @@ ICS;
         $this->process($itip, $old, $expected);
     }
 
+    public function testReplyExistingExceptionRecurrenceIdInUTC(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID:20140725T040000Z
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED;SCHEDULE-STATUS=2.0:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
+    }
+
     public function testReplyNewException(): void
     {
         // This is a reply to 1 instance of a recurring event. This should
@@ -326,6 +395,126 @@ ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
 ORGANIZER:mailto:bar@example.org
 SEQUENCE:2
 RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
+    }
+
+    public function testReplyNewExceptionRecurrenceIdInDifferentTz(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID;TZID=Asia/Ho_Chi_Minh:20140725T110000
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
+    }
+
+    public function testReplyNewExceptionRecurrenceIdInUTC(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID:20140725T040000Z
 UID:foobar
 END:VEVENT
 END:VCALENDAR

--- a/tests/VObject/ITip/BrokerProcessReplyTest.php
+++ b/tests/VObject/ITip/BrokerProcessReplyTest.php
@@ -255,8 +255,6 @@ ICS;
 
     public function testReplyExistingExceptionRecurrenceIdInUTC(): void
     {
-        // This is a reply to 1 instance of a recurring event. This should
-        // automatically create an exception.
         $itip = <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0


### PR DESCRIPTION
fixes #358, closes #360

While rebasing #360, I noticed that it only fixes replies to new exception events. I use a different approach now, which also fixes replies to existing exception events.