### PR TITLE
Yearly rrule compliance by the iterator

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -610,7 +610,11 @@ class RRuleIterator implements \Iterator
                     // If we advanced to the next month or year, the first
                     // occurrence is always correct.
                     if ($occurrence > $currentDayOfMonth || $advancedToNewMonth) {
-                        break 2;
+                        // only consider byMonth matches,
+                        // otherwise, we don't follow RRule correctly
+                        if (in_array($currentMonth, $this->byMonth)) {
+                            break 2;
+                        }
                     }
                 }
 

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -923,6 +923,23 @@ class RRuleIteratorTest extends TestCase
     }
 
     /**
+     * This caused an incorrect date to be returned by the rule iterator when
+     * start date was not on the rrule list.
+     */
+    public function testYearlyStartDateNotOnRRuleList(): void
+    {
+        $this->parse(
+            'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
+            '2023-09-01 12:00:00',
+            [
+                '2023-09-01 12:00:00',
+                '2024-06-28 12:00:00',
+                '2025-06-27 12:00:00',
+            ],
+        );
+    }
+
+    /**
      * Something, somewhere produced an ics with an interval set to 0. Because
      * this means we increase the current day (or week, month) by 0, this also
      * results in an infinite loop.


### PR DESCRIPTION
Make the RRuleIterator always follow the yearly RRULE even when start date does not follow the rule. Should solve https://github.com/sabre-io/vobject/issues/626