### PR TITLE
throw ParseException when null input is provided

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -79,6 +79,12 @@ class MimeDir extends Parser
             $this->setInput($input);
         }
 
+        if (!\is_resource($this->input)) {
+            // Null was passed as input, but there was no existing input buffer
+            // There is nothing to parse.
+            throw new ParseException('No input provided to parse');
+        }
+
         if (0 !== $options) {
             $this->options = $options;
         }

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -101,6 +101,25 @@ VCF;
         $mimeDir->parse($vcard);
     }
 
+    public function provideEmptyParserInput(): array
+    {
+        return [
+            [null, 'No input provided to parse'],
+            ['', 'End of document reached prematurely'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmptyParserInput
+     */
+    public function testParseEmpty($input, $expectedExceptionMessage): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $mimeDir = new MimeDir();
+        $mimeDir->parse($input);
+    }
+
     public function testDecodeWindows1252(): void
     {
         $vcard = <<<VCF


### PR DESCRIPTION
Issue #657 

`parse` can be called with input `null`, but the caller should have previously provided an input stream that is already set up.

The change in this PR makes `parse` throw a `ParseException` if it is called the first time with `null`

This should help anyone calling this, or `Reader::read()` with no input. Instead of getting a PHP Fatal error, they will get an exception.