### PR TITLE
Backport from master branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.php_cs.dist export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /CHANGELOG.md export-ignore
 /phpstan.neon export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             code-analysis: 'yes'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,5 @@ jobs:
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         if: matrix.coverage != 'none'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
         code-analysis: ['no']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -186,10 +186,8 @@ abstract class Document extends Component
      * @param mixed  $value
      * @param array  $parameters
      * @param string $valueType  Force a specific valuetype, such as URI or TEXT
-     *
-     * @return Property
      */
-    public function createProperty($name, $value = null, array $parameters = null, $valueType = null)
+    public function createProperty($name, $value = null, array $parameters = null, $valueType = null, ?int $lineIndex = null, ?string $lineString = null): Property
     {
         // If there's a . in the name, it means it's prefixed by a groupname.
         if (false !== ($i = strpos($name, '.'))) {
@@ -223,7 +221,7 @@ abstract class Document extends Component
             $parameters = [];
         }
 
-        return new $class($this, $name, $value, $parameters, $group);
+        return new $class($this, $name, $value, $parameters, $group, $lineIndex, $lineString);
     }
 
     /**

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -187,7 +187,7 @@ abstract class Document extends Component
      * @param array  $parameters
      * @param string $valueType  Force a specific valuetype, such as URI or TEXT
      */
-    public function createProperty($name, $value = null, array $parameters = null, $valueType = null, ?int $lineIndex = null, ?string $lineString = null): Property
+    public function createProperty($name, $value = null, array $parameters = null, $valueType = null, int $lineIndex = null, string $lineString = null): Property
     {
         // If there's a . in the name, it means it's prefixed by a groupname.
         if (false !== ($i = strpos($name, '.'))) {

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -338,6 +338,9 @@ class Broker
 
         // Finding all the instances the attendee replied to.
         foreach ($itipMessage->message->VEVENT as $vevent) {
+            // Use the Unix timestamp returned by getTimestamp as a unique identifier for the recurrence.
+            // The Unix timestamp will be the same for an event, even if the reply from the attendee
+            // used a different format/timezone to express the event date-time.
             $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             $attendee = $vevent->ATTENDEE;
             $instances[$recurId] = $attendee['PARTSTAT']->getValue();
@@ -351,6 +354,7 @@ class Broker
         // all the instances where we have a reply for.
         $masterObject = null;
         foreach ($existingObject->VEVENT as $vevent) {
+            // Use the Unix timestamp returned by getTimestamp as a unique identifier for the recurrence.
             $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             if ('master' === $recurId) {
                 $masterObject = $vevent;
@@ -398,6 +402,9 @@ class Broker
                 $newObject = $recurrenceIterator->getEventObject();
                 $recurrenceIterator->next();
 
+                // Compare the Unix timestamp returned by getTimestamp with the previously calculated timestamp.
+                // If they are the same, then this is a matching recurrence, even though its date-time may have
+                // been expressed in a different format/timezone.
                 if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() === $recurId) {
                     $found = true;
                 }

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -338,7 +338,7 @@ class Broker
 
         // Finding all the instances the attendee replied to.
         foreach ($itipMessage->message->VEVENT as $vevent) {
-            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getValue() : 'master';
+            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             $attendee = $vevent->ATTENDEE;
             $instances[$recurId] = $attendee['PARTSTAT']->getValue();
             if (isset($vevent->{'REQUEST-STATUS'})) {
@@ -351,7 +351,7 @@ class Broker
         // all the instances where we have a reply for.
         $masterObject = null;
         foreach ($existingObject->VEVENT as $vevent) {
-            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getValue() : 'master';
+            $recurId = isset($vevent->{'RECURRENCE-ID'}) ? $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() : 'master';
             if ('master' === $recurId) {
                 $masterObject = $vevent;
             }
@@ -398,7 +398,7 @@ class Broker
                 $newObject = $recurrenceIterator->getEventObject();
                 $recurrenceIterator->next();
 
-                if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getValue() === $recurId) {
+                if (isset($newObject->{'RECURRENCE-ID'}) && $newObject->{'RECURRENCE-ID'}->getDateTime()->getTimestamp() === $recurId) {
                     $found = true;
                 }
                 --$iterations;

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -447,7 +447,7 @@ class MimeDir extends Parser
             }
         }
 
-        $propObj = $this->root->createProperty($property['name'], null, $namedParameters);
+        $propObj = $this->root->createProperty($property['name'], null, $namedParameters, null, $this->startLine, $line);
 
         foreach ($namelessParameters as $namelessParameter) {
             $propObj->add(null, $namelessParameter);

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -83,6 +83,12 @@ class MimeDir extends Parser
             $this->setInput($input);
         }
 
+        if (!\is_resource($this->input)) {
+            // Null was passed as input, but there was no existing input buffer
+            // There is nothing to parse.
+            throw new ParseException('No input provided to parse');
+        }
+
         if (0 !== $options) {
             $this->options = $options;
         }

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -61,14 +61,14 @@ abstract class Property extends Node
      *   that corresponds with the current node
      *   if the node was read from a file.
      */
-    public ?int $lineIndex;
+    public $lineIndex;
 
     /**
      * The line string from the original iCalendar / vCard file
      *   that corresponds with the current node
      *   if the node was read from a file.
      */
-    public ?string $lineString;
+    public $lineString;
 
     /**
      * Creates the generic property.
@@ -81,7 +81,7 @@ abstract class Property extends Node
      * @param array             $parameters List of parameters
      * @param string            $group      The vcard property group
      */
-    public function __construct(Component $root, $name, $value = null, array $parameters = [], $group = null, ?int $lineIndex = null, ?string $lineString = null)
+    public function __construct(Component $root, $name, $value = null, array $parameters = [], $group = null, int $lineIndex = null, string $lineString = null)
     {
         $this->name = $name;
         $this->group = $group;

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -57,6 +57,20 @@ abstract class Property extends Node
     public $delimiter = ';';
 
     /**
+     * The line number in the original iCalendar / vCard file
+     *   that corresponds with the current node
+     *   if the node was read from a file.
+     */
+    public ?int $lineIndex;
+
+    /**
+     * The line string from the original iCalendar / vCard file
+     *   that corresponds with the current node
+     *   if the node was read from a file.
+     */
+    public ?string $lineString;
+
+    /**
      * Creates the generic property.
      *
      * Parameters must be specified in key=>value syntax.
@@ -67,7 +81,7 @@ abstract class Property extends Node
      * @param array             $parameters List of parameters
      * @param string            $group      The vcard property group
      */
-    public function __construct(Component $root, $name, $value = null, array $parameters = [], $group = null)
+    public function __construct(Component $root, $name, $value = null, array $parameters = [], $group = null, ?int $lineIndex = null, ?string $lineString = null)
     {
         $this->name = $name;
         $this->group = $group;
@@ -80,6 +94,14 @@ abstract class Property extends Node
 
         if (!is_null($value)) {
             $this->setValue($value);
+        }
+
+        if (!is_null($lineIndex)) {
+            $this->lineIndex = $lineIndex;
+        }
+
+        if (!is_null($lineString)) {
+            $this->lineString = $lineString;
         }
     }
 

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -651,7 +651,11 @@ class RRuleIterator implements Iterator
                     // If we advanced to the next month or year, the first
                     // occurrence is always correct.
                     if ($occurrence > $currentDayOfMonth || $advancedToNewMonth) {
-                        break 2;
+                        // only consider byMonth matches,
+                        // otherwise, we don't follow RRule correctly
+                        if (in_array($currentMonth, $this->byMonth)) {
+                            break 2;
+                        }
                     }
                 }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 parameters:
   level: 1
+  reportUnmatchedIgnoredErrors: false
   universalObjectCratesClasses:
     - \Sabre\VObject\Component
+  ignoreErrors:
+    - '#Call to an undefined static method Sabre\\VObject\\Component\\VCalendarTest::assertObjectHasProperty\(\).#'

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -757,6 +757,49 @@ ICS;
         );
     }
 
+    public function testNodeInValidationErrorHasLineIndexAndLineStringProps(): void
+    {
+        $defectiveInput = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:PUBLISH
+PRODID:vobject
+BEGIN:VEVENT
+UID:foo
+CLASS:PUBLIC
+DTSTART;VALUE=DATE:19931231
+DTSTAMP:20240422T070855Z
+CREATED:
+LAST-MODIFIED:
+DESCRIPTION:bar
+END:VEVENT
+ICS;
+
+        $vcal = VObject\Reader::read($defectiveInput);
+        $result = $vcal->validate();
+        $warningMessages = [];
+        foreach ($result as $error) {
+            $warningMessages[] = $error['message'];
+        }
+        self::assertCount(2, $result, 'We expected exactly 2 validation messages, instead we got '.count($result).' results:'.implode(', ', $warningMessages));
+        foreach ($result as $idx => $warning) {
+            self::assertArrayHasKey('node', $warning, 'The validation errors should contain a node key');
+            self::assertInstanceOf(VObject\Property\ICalendar\DateTime::class, $warning['node'], 'We expected the defective node to be of type Sabre\VObject\Property\ICalendar\DateTime, instead we got type '.gettype($warning['node']));
+            self::assertObjectHasProperty('lineIndex', $warning['node'], 'We expected the defective node in the validation errors array to have a "lineIndex" property');
+            self::assertObjectHasProperty('lineString', $warning['node'], 'We expected the defective node in the validation errors array to have a "lineString" property');
+            switch ($idx) {
+                case 0:
+                    self::assertEquals('10', $warning['node']->lineIndex, 'We expected the "lineIndex" property of the first defective node to be 10, instead it was '.$warning['node']->lineIndex);
+                    self::assertEquals('CREATED:', $warning['node']->lineString, 'We expected the "lineString" property of the first defective node to be "CREATED:", instead it was '.$warning['node']->lineString);
+                    break;
+                case 1:
+                    self::assertEquals('11', $warning['node']->lineIndex, 'We expected the "lineIndex" property of the second defective node to be 11, instead it was '.$warning['node']->lineIndex);
+                    self::assertEquals('LAST-MODIFIED:', $warning['node']->lineString, 'We expected the "lineString" property of the second defective node to be "LAST-MODIFIED:", instead it was '.$warning['node']->lineString);
+                    break;
+            }
+        }
+    }
+
     public function assertValidate($ics, $options, $expectedLevel, $expectedMessage = null)
     {
         $vcal = VObject\Reader::read($ics);

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -785,8 +785,14 @@ ICS;
         foreach ($result as $idx => $warning) {
             self::assertArrayHasKey('node', $warning);
             self::assertInstanceOf(VObject\Property\ICalendar\DateTime::class, $warning['node']);
-            self::assertObjectHasProperty('lineIndex', $warning['node']);
-            self::assertObjectHasProperty('lineString', $warning['node']);
+            if (method_exists($this, 'assertObjectHasProperty')) {
+                self::assertObjectHasProperty('lineIndex', $warning['node']);
+                self::assertObjectHasProperty('lineString', $warning['node']);
+            } else {
+                // Fall back to the older method name known to older versions of phpunit.
+                self::assertObjectHasAttribute('lineIndex', $warning['node']);
+                self::assertObjectHasAttribute('lineString', $warning['node']);
+            }
             switch ($idx) {
                 case 0:
                     self::assertEquals('10', $warning['node']->lineIndex);

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -783,18 +783,18 @@ ICS;
         }
         self::assertCount(2, $result, 'We expected exactly 2 validation messages, instead we got '.count($result).' results:'.implode(', ', $warningMessages));
         foreach ($result as $idx => $warning) {
-            self::assertArrayHasKey('node', $warning, 'The validation errors should contain a node key');
-            self::assertInstanceOf(VObject\Property\ICalendar\DateTime::class, $warning['node'], 'We expected the defective node to be of type Sabre\VObject\Property\ICalendar\DateTime, instead we got type '.gettype($warning['node']));
-            self::assertObjectHasProperty('lineIndex', $warning['node'], 'We expected the defective node in the validation errors array to have a "lineIndex" property');
-            self::assertObjectHasProperty('lineString', $warning['node'], 'We expected the defective node in the validation errors array to have a "lineString" property');
+            self::assertArrayHasKey('node', $warning);
+            self::assertInstanceOf(VObject\Property\ICalendar\DateTime::class, $warning['node']);
+            self::assertObjectHasProperty('lineIndex', $warning['node']);
+            self::assertObjectHasProperty('lineString', $warning['node']);
             switch ($idx) {
                 case 0:
-                    self::assertEquals('10', $warning['node']->lineIndex, 'We expected the "lineIndex" property of the first defective node to be 10, instead it was '.$warning['node']->lineIndex);
-                    self::assertEquals('CREATED:', $warning['node']->lineString, 'We expected the "lineString" property of the first defective node to be "CREATED:", instead it was '.$warning['node']->lineString);
+                    self::assertEquals('10', $warning['node']->lineIndex);
+                    self::assertEquals('CREATED:', $warning['node']->lineString);
                     break;
                 case 1:
-                    self::assertEquals('11', $warning['node']->lineIndex, 'We expected the "lineIndex" property of the second defective node to be 11, instead it was '.$warning['node']->lineIndex);
-                    self::assertEquals('LAST-MODIFIED:', $warning['node']->lineString, 'We expected the "lineString" property of the second defective node to be "LAST-MODIFIED:", instead it was '.$warning['node']->lineString);
+                    self::assertEquals('11', $warning['node']->lineIndex);
+                    self::assertEquals('LAST-MODIFIED:', $warning['node']->lineString);
                     break;
             }
         }

--- a/tests/VObject/ITip/BrokerProcessReplyTest.php
+++ b/tests/VObject/ITip/BrokerProcessReplyTest.php
@@ -255,8 +255,6 @@ ICS;
 
     public function testReplyExistingExceptionRecurrenceIdInUTC(): void
     {
-        // This is a reply to 1 instance of a recurring event. This should
-        // automatically create an exception.
         $itip = <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0

--- a/tests/VObject/ITip/BrokerProcessReplyTest.php
+++ b/tests/VObject/ITip/BrokerProcessReplyTest.php
@@ -253,6 +253,75 @@ ICS;
         $result = $this->process($itip, $old, $expected);
     }
 
+    public function testReplyExistingExceptionRecurrenceIdInUTC(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID:20140725T040000Z
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED;SCHEDULE-STATUS=2.0:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
+    }
+
     public function testReplyNewException()
     {
         // This is a reply to 1 instance of a recurring event. This should
@@ -371,6 +440,126 @@ END:VCALENDAR
 ICS;
 
         $result = $this->process($itip, $old, $expected);
+    }
+
+    public function testReplyNewExceptionRecurrenceIdInDifferentTz(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID;TZID=Asia/Ho_Chi_Minh:20140725T110000
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
+    }
+
+    public function testReplyNewExceptionRecurrenceIdInUTC(): void
+    {
+        // This is a reply to 1 instance of a recurring event. This should
+        // automatically create an exception.
+        $itip = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+SEQUENCE:2
+RECURRENCE-ID:20140725T040000Z
+UID:foobar
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $old = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART;TZID=America/Toronto:20140724T000000
+DTEND;TZID=America/Toronto:20140724T010000
+ATTENDEE:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+END:VEVENT
+BEGIN:VEVENT
+SEQUENCE:2
+UID:foobar
+DTSTART;TZID=America/Toronto:20140725T000000
+DTEND;TZID=America/Toronto:20140725T010000
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:foo@example.org
+ORGANIZER:mailto:bar@example.org
+RECURRENCE-ID;TZID=America/Toronto:20140725T000000
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $this->process($itip, $old, $expected);
     }
 
     public function testReplyPartyCrashCreateException()

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -101,6 +101,25 @@ VCF;
         $mimeDir->parse($vcard);
     }
 
+    public function provideEmptyParserInput(): array
+    {
+        return [
+            [null, 'No input provided to parse'],
+            ['', 'End of document reached prematurely'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmptyParserInput
+     */
+    public function testParseEmpty($input, $expectedExceptionMessage): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $mimeDir = new MimeDir();
+        $mimeDir->parse($input);
+    }
+
     public function testDecodeWindows1252()
     {
         $vcard = <<<VCF

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -928,18 +928,47 @@ class RRuleIteratorTest extends TestCase
     /**
      * This caused an incorrect date to be returned by the rule iterator when
      * start date was not on the rrule list.
+     *
+     * @dataProvider yearlyStartDateNotOnRRuleListProvider
      */
-    public function testYearlyStartDateNotOnRRuleList(): void
+    public function testYearlyStartDateNotOnRRuleList(string $rule, string $start, array $expected): void
     {
-        $this->parse(
-            'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
-            '2023-09-01 12:00:00',
+        $this->parse($rule, $start, $expected);
+    }
+
+    public function yearlyStartDateNotOnRRuleListProvider(): array
+    {
+        return [
             [
+                'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
                 '2023-09-01 12:00:00',
-                '2024-06-28 12:00:00',
-                '2025-06-27 12:00:00',
+                [
+                    '2023-09-01 12:00:00',
+                    '2024-06-28 12:00:00',
+                    '2025-06-27 12:00:00',
+                ],
             ],
-        );
+            [
+                'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
+                '2023-06-01 12:00:00',
+                [
+                    '2023-06-01 12:00:00',
+                    '2023-06-30 12:00:00',
+                    '2024-06-28 12:00:00',
+                    '2025-06-27 12:00:00',
+                ],
+            ],
+            [
+                'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
+                '2023-05-01 12:00:00',
+                [
+                    '2023-05-01 12:00:00',
+                    '2023-06-30 12:00:00',
+                    '2024-06-28 12:00:00',
+                    '2025-06-27 12:00:00',
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -926,6 +926,23 @@ class RRuleIteratorTest extends TestCase
     }
 
     /**
+     * This caused an incorrect date to be returned by the rule iterator when
+     * start date was not on the rrule list.
+     */
+    public function testYearlyStartDateNotOnRRuleList(): void
+    {
+        $this->parse(
+            'FREQ=YEARLY;BYMONTH=6;BYDAY=-1FR;UNTIL=20250901T000000Z',
+            '2023-09-01 12:00:00',
+            [
+                '2023-09-01 12:00:00',
+                '2024-06-28 12:00:00',
+                '2025-06-27 12:00:00',
+            ],
+        );
+    }
+
+    /**
      * Something, somewhere produced an ics with an interval set to 0. Because
      * this means we increase the current day (or week, month) by 0, this also
      * results in an infinite loop.


### PR DESCRIPTION
Backport changes from master that have happened since release https://github.com/sabre-io/vobject/releases/tag/4.5.4 on 2023-11-09

These come from PRs
#632 Add PHP 8.3 to CI
#637 Bump GitHub workflow actions/cache to 4
#638 Bump codecov/codecov-action to 4
#649 add lineIndex and lineString properties to a Property Node
#652 ITip\Broker: handle timezones in replies to exception events
#654 chore: stop exporting php-cs-fixer config
#656 Yearly rrule compliance by the iterator
#658 throw ParseException when null input is provided

I had to remove some code like `?int` that does not work on PHP 7.1 (just declare the parameter `int`). But everything seems to work right back to PHP 7.1, and all tests pass.

This keeps the 4.5 branch up-to-date with fixes/changes that are pending release.