### PR TITLE
Fix VTODO validation for PERCENT-COMPLETE

### DIFF
--- a/lib/Component/VTodo.php
+++ b/lib/Component/VTodo.php
@@ -104,7 +104,7 @@ class VTodo extends VObject\Component
             'LAST-MODIFIED' => '?',
             'LOCATION' => '?',
             'ORGANIZER' => '?',
-            'PERCENT' => '?',
+            'PERCENT-COMPLETE' => '?',
             'PRIORITY' => '?',
             'RECURRENCE-ID' => '?',
             'SEQUENCE' => '?',

--- a/tests/VObject/Component/VTodoTest.php
+++ b/tests/VObject/Component/VTodoTest.php
@@ -168,4 +168,31 @@ HI;
             'DUE must occur after DTSTART',
         ], $messages);
     }
+
+    public function testValidateDuplicatePercentComplete(): void
+    {
+        $input = <<<HI
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:YoYo
+BEGIN:VTODO
+UID:8ed267e1-67c4-467d-8ae2-28e6ff03b033
+DTSTAMP:20240729T133309Z
+PERCENT-COMPLETE:70
+PERCENT-COMPLETE:80
+END:VTODO
+END:VCALENDAR
+HI;
+        $obj = Reader::read($input);
+
+        $warnings = $obj->validate();
+        $messages = [];
+        foreach ($warnings as $warning) {
+            $messages[] = $warning['message'];
+        }
+
+        self::assertEquals([
+            'PERCENT-COMPLETE MUST NOT appear more than once in a VTODO component',
+        ], $messages);
+    }
 }


### PR DESCRIPTION
This PR should fix the linked issue I created about the `PERCENT-COMPLETE` property of the `VTODO` being misspelled as just `PERCENT`. I also added a test to verify that the validation of the property now works as expected. If you think the test is unnecessary, I can also just remove it again.

Fixes #663 