### PR TITLE
chore: adjust code to make php-cs-fixer and phpstan pass

### DIFF
--- a/bin/bench.php
+++ b/bin/bench.php
@@ -7,6 +7,6 @@ $data = stream_get_contents(STDIN);
 
 $start = microtime(true);
 
-$lol = Sabre\VObject\Reader::read($data);
+$lol = VObject\Reader::read($data);
 
 echo 'time: '.(microtime(true) - $start)."\n";

--- a/bin/bench_freebusygenerator.php
+++ b/bin/bench_freebusygenerator.php
@@ -3,7 +3,7 @@
 include __DIR__.'/../vendor/autoload.php';
 
 if ($argc < 2) {
-    echo 'sabre/vobject ', Sabre\VObject\Version::VERSION, " freebusy benchmark\n";
+    echo 'sabre/vobject ', VObject\Version::VERSION, " freebusy benchmark\n";
     echo "\n";
     echo "This script can be used to measure the speed of generating a\n";
     echo "free-busy report based on a calendar.\n";
@@ -19,7 +19,7 @@ list(, $inputFile) = $argv;
 $bench = new Hoa\Bench\Bench();
 $bench->parse->start();
 
-$vcal = Sabre\VObject\Reader::read(fopen($inputFile, 'r'));
+$vcal = VObject\Reader::read(fopen($inputFile, 'r'));
 
 $bench->parse->stop();
 
@@ -31,7 +31,7 @@ $timeZone = new DateTimeZone('America/Toronto');
 $bench->fb->start();
 
 for ($i = 0; $i < $repeat; ++$i) {
-    $fb = new Sabre\VObject\FreeBusyGenerator($start, $end, $vcal, $timeZone);
+    $fb = new VObject\FreeBusyGenerator($start, $end, $vcal, $timeZone);
     $results = $fb->getResult();
 }
 $bench->fb->stop();

--- a/bin/bench_manipulatevcard.php
+++ b/bin/bench_manipulatevcard.php
@@ -3,7 +3,7 @@
 include __DIR__.'/../vendor/autoload.php';
 
 if ($argc < 2) {
-    echo 'sabre/vobject ', Sabre\VObject\Version::VERSION, " manipulation benchmark\n";
+    echo 'sabre/vobject ', VObject\Version::VERSION, " manipulation benchmark\n";
     echo "\n";
     echo "This script can be used to measure the speed of opening a large amount of\n";
     echo "vcards, making a few alterations and serializing them again.\n";
@@ -17,7 +17,7 @@ list(, $inputFile) = $argv;
 
 $input = file_get_contents($inputFile);
 
-$splitter = new Sabre\VObject\Splitter\VCard($input);
+$splitter = new VObject\Splitter\VCard($input);
 
 $bench = new Hoa\Bench\Bench();
 

--- a/bin/rrulebench.php
+++ b/bin/rrulebench.php
@@ -3,7 +3,7 @@
 include __DIR__.'/../vendor/autoload.php';
 
 if ($argc < 4) {
-    echo 'sabre/vobject ', Sabre\VObject\Version::VERSION, " RRULE benchmark\n";
+    echo 'sabre/vobject ', VObject\Version::VERSION, " RRULE benchmark\n";
     echo "\n";
     echo "This script can be used to measure the speed of the 'recurrence expansion'\n";
     echo 'system.';
@@ -18,7 +18,7 @@ $bench = new Hoa\Bench\Bench();
 $bench->parse->start();
 
 echo "Parsing.\n";
-$vobj = Sabre\VObject\Reader::read(fopen($inputFile, 'r'));
+$vobj = VObject\Reader::read(fopen($inputFile, 'r'));
 
 $bench->parse->stop();
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.63",
+        "friendsofphp/php-cs-fixer": "3.62.0",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^1.12"

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.54",
+        "friendsofphp/php-cs-fixer": "^3.63",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
-        "phpstan/phpstan": "^1.11"
+        "phpstan/phpstan": "^1.12"
     },
     "suggest" : {
         "hoa/bench"       : "If you would like to run the benchmark scripts"

--- a/tests/VObject/ITip/BrokerDeleteEventTest.php
+++ b/tests/VObject/ITip/BrokerDeleteEventTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\VObject\ITip;
 
+use Sabre\VObject\Version;
+
 class BrokerDeleteEventTest extends BrokerTester
 {
     public function testOrganizerDeleteWithDtend(): void
@@ -24,7 +26,7 @@ ICS;
 
         $newMessage = null;
 
-        $version = \Sabre\VObject\Version::VERSION;
+        $version = Version::VERSION;
 
         $expected = [
             [
@@ -107,7 +109,7 @@ ICS;
 
         $newMessage = null;
 
-        $version = \Sabre\VObject\Version::VERSION;
+        $version = Version::VERSION;
 
         $expected = [
             [
@@ -190,7 +192,7 @@ ICS;
 
         $newMessage = null;
 
-        $version = \Sabre\VObject\Version::VERSION;
+        $version = Version::VERSION;
 
         $expected = [
             [
@@ -245,7 +247,7 @@ ICS;
 
         $newMessage = null;
 
-        $version = \Sabre\VObject\Version::VERSION;
+        $version = Version::VERSION;
 
         $expected = [
             [


### PR DESCRIPTION
The latest php-cs-fixer and phpstan want to make a few changes.

I needed to pin php-cs-fixer to 3.62.0 because of issue https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8182

After that is fixed, we can probably move to 3.63