### PR TITLE
chore: use php-cs-fixer 3.63

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "3.62.0",
+        "friendsofphp/php-cs-fixer": "^3.63",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^1.12"


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.63.2 has been released.
That fixed https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8182
So now we are fine to use the php-cs-fixer 3.63 series.