### PR TITLE
Allow unknown value data types for VALUE

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -186,8 +186,8 @@ abstract class Document extends Component
         //  parameter need not be specified.  However, if the property's
         //  default value type is overridden by some other allowable value
         //  type, then this parameter MUST be specified.
-        if (isset($parameters['VALUE'])) {
-            $class = $this->getClassNameForPropertyValue($parameters['VALUE']);
+        if (!$valueType) {
+            $valueType = $parameters['VALUE'] ?? null;
         }
 
         if ($valueType) {

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -180,23 +180,30 @@ abstract class Document extends Component
 
         $class = null;
 
+        // If a VALUE parameter is supplied, we have to use that
+        // According to https://datatracker.ietf.org/doc/html/rfc5545#section-3.2.20
+        //  If the property's value is the default value type, then this
+        //  parameter need not be specified.  However, if the property's
+        //  default value type is overridden by some other allowable value
+        //  type, then this parameter MUST be specified.
+        if (isset($parameters['VALUE'])) {
+            $class = $this->getClassNameForPropertyValue($parameters['VALUE']);
+        }
+
         if ($valueType) {
             // The valueType argument comes first to figure out the correct
             // class.
             $class = $this->getClassNameForPropertyValue($valueType);
         }
 
+        // If the value parameter is not set or set to something we do not recognize
+        // we do not attempt to interpret or parse the datass value as specified in
+        // https://datatracker.ietf.org/doc/html/rfc5545#section-3.2.20
+        // So when we so far did not get a class-name, we use the default for the property
         if (is_null($class)) {
-            // If a VALUE parameter is supplied, we should use that.
-            if (isset($parameters['VALUE'])) {
-                $class = $this->getClassNameForPropertyValue($parameters['VALUE']);
-                if (is_null($class)) {
-                    throw new InvalidDataException('Unsupported VALUE parameter for '.$name.' property. You supplied "'.$parameters['VALUE'].'"');
-                }
-            } else {
-                $class = $this->getClassNameForPropertyName($name);
-            }
+            $class = $this->getClassNameForPropertyName($name);
         }
+
         if (is_null($parameters)) {
             $parameters = [];
         }

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -5,6 +5,7 @@ namespace Sabre\VObject;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VCard;
+use Sabre\VObject\Property\ICalendar\DateTime;
 
 class PropertyTest extends TestCase
 {
@@ -390,5 +391,19 @@ class PropertyTest extends TestCase
 
         self::assertEquals('ENCODING=B is not valid for this document type.', $result[0]['message']);
         self::assertEquals(3, $result[0]['level']);
+    }
+
+    public function testUnknownValuesWillBeIgnored(): void
+    {
+        $cal = new VCalendar();
+        $property = $cal->createProperty('DTSTAMP', '20240101T000000Z', ['VALUE' => 'DATETIME']);
+
+        self::assertEquals("DTSTAMP;VALUE=DATETIME:20240101T000000Z\r\n", $property->serialize());
+
+        self::assertInstanceOf(DateTime::class, $property);
+        self::assertCount(1, $property->parameters());
+        self::assertInstanceOf(Parameter::class, $property->parameters['VALUE']);
+        self::assertEquals('VALUE', $property->parameters['VALUE']->name);
+        self::assertEquals('DATETIME', $property->parameters['VALUE']->getValue());
     }
 }


### PR DESCRIPTION
Currently value-types that are not known will cause the parser to throw an InvalidDataException. In [RFC5545, Section 3.2.20](https://datatracker.ietf.org/doc/html/rfc5545#section-3.2.20) is described though that the allowed values for the "VALUE" data-type can include x-names and iana-tokens. These can be any string that might - or might not - be understood by the parser. The description clearly states that "Applications MUST preserve the value data for x-name and iana-token value that they don't recognize without attempting to interpret or parse the value data"

This means that the content of the "VALUE" part should not be interpreted at all the moment the parser doesn't find a match in the corresponding mapping table.

But it should also not hard-fail when someone sets a VALUE that might not be understood. In such a case the default should be used instead.