### PR TITLE
fix: include RDATE in busy calculation

### DIFF
--- a/lib/FreeBusyGenerator.php
+++ b/lib/FreeBusyGenerator.php
@@ -359,7 +359,7 @@ class FreeBusyGenerator
 
                         $times = [];
 
-                        if ($component->RRULE) {
+                        if ($component->RRULE || $component->RDATE) {
                             try {
                                 $iterator = new EventIterator($object, (string) $component->UID, $this->timeZone);
                             } catch (NoInstancesException $e) {


### PR DESCRIPTION
fix: include RDATE in busy calculation

ICal spec allows for events with only an RDATE. At the moment if an event only includes an RDATE and no RRULE it is skipped due to the current code path only checking for the existence of a RRULE.

RFC Reference https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.5.2 