### PR TITLE
[4.5] refactor: Replace dirname(__FILE__) with __DIR__

### DIFF
--- a/tests/VObject/Issue153Test.php
+++ b/tests/VObject/Issue153Test.php
@@ -8,7 +8,7 @@ class Issue153Test extends TestCase
 {
     public function testRead()
     {
-        $obj = Reader::read(file_get_contents(dirname(__FILE__).'/issue153.vcf'));
+        $obj = Reader::read(file_get_contents(__DIR__.'/issue153.vcf'));
         $this->assertEquals('Test Benutzer', (string) $obj->FN);
     }
 }

--- a/tests/VObject/Issue64Test.php
+++ b/tests/VObject/Issue64Test.php
@@ -8,7 +8,7 @@ class Issue64Test extends TestCase
 {
     public function testRead()
     {
-        $vcard = Reader::read(file_get_contents(dirname(__FILE__).'/issue64.vcf'));
+        $vcard = Reader::read(file_get_contents(__DIR__.'/issue64.vcf'));
         $vcard = $vcard->convert(\Sabre\VObject\Document::VCARD30);
         $vcard = $vcard->serialize();
 


### PR DESCRIPTION
Backport #675 from master, just to keep the test code as much in sync as possible.