### PR TITLE
[4.5] Throw InvalidDataException when RRule is invalid

### DIFF
--- a/lib/Property/ICalendar/Recur.php
+++ b/lib/Property/ICalendar/Recur.php
@@ -198,7 +198,14 @@ class Recur extends Property
             if (empty($part)) {
                 continue;
             }
-            list($partName, $partValue) = explode('=', $part);
+
+            $parts = explode('=', $part);
+
+            if (2 !== count($parts)) {
+                throw new InvalidDataException('The supplied iCalendar RRULE part is incorrect: '.$part);
+            }
+
+            list($partName, $partValue) = $parts;
 
             // The value itself had multiple values..
             if (false !== strpos($partValue, ',')) {

--- a/lib/Property/ICalendar/Recur.php
+++ b/lib/Property/ICalendar/Recur.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use Sabre\VObject\InvalidDataException;
 use Sabre\VObject\Property;
 use Sabre\Xml;
 

--- a/tests/VObject/Property/ICalendar/RecurTest.php
+++ b/tests/VObject/Property/ICalendar/RecurTest.php
@@ -197,11 +197,9 @@ END:VCALENDAR
 
     public function testUnrepairableRRule()
     {
+        $this->expectException(InvalidDataException::class);
         $calendar = new VCalendar();
         $property = $calendar->createProperty('RRULE', 'IAmNotARRule');
-
-        $this->expectException(InvalidDataException::class);
-
         $property->validate(Node::REPAIR);
     }
 

--- a/tests/VObject/Property/ICalendar/RecurTest.php
+++ b/tests/VObject/Property/ICalendar/RecurTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Property\ICalendar;
 
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\InvalidDataException;
 use Sabre\VObject\Node;
 use Sabre\VObject\Reader;
 
@@ -192,6 +193,16 @@ END:VCALENDAR
             $expected,
             $vcal
         );
+    }
+
+    public function testUnrepairableRRule()
+    {
+        $calendar = new VCalendar();
+        $property = $calendar->createProperty('RRULE', 'IAmNotARRule');
+
+        $this->expectException(InvalidDataException::class);
+
+        $property->validate(Node::REPAIR);
     }
 
     public function testValidateInvalidByMonthRruleWithRepair()


### PR DESCRIPTION
Backport #692 to 4.5 branch

In master, `use Sabre\VObject\InvalidDataException;` is already there, because various declarations of things, parameter types, return types etc have been added in master. I had to add the `use` statement in the backport.