### PR TITLE
chore: bump php-cs-fixer to 3.65

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/xml"    : "^3.0 || ^4.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.64",
+        "friendsofphp/php-cs-fixer": "^3.65",
         "phpunit/phpunit" : "^9.6",
         "phpunit/php-invoker" : "^2.0 || ^3.1",
         "phpstan/phpstan": "^1.12"

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -164,7 +164,7 @@ class VCalendar extends VObject\Document
      *
      * @param string|null $componentName filter by component name
      *
-     * @return VObject\Component[]
+     * @return Component[]
      */
     public function getBaseComponents(?string $componentName = null): array
     {


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.65.0 was released last week.

It finds just one minor thing to change in the source code. Apply that change so that CI will pass.