### PR TITLE
add phpdoc return types for arrayaccess methods (fixes #563)

### DIFF
--- a/lib/ElementList.php
+++ b/lib/ElementList.php
@@ -24,6 +24,7 @@ class ElementList extends ArrayIterator
      *
      * @param int   $offset
      * @param mixed $value
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -37,6 +38,7 @@ class ElementList extends ArrayIterator
      * This method just forwards the request to the inner iterator
      *
      * @param int $offset
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/lib/ElementList.php
+++ b/lib/ElementList.php
@@ -24,6 +24,7 @@ class ElementList extends ArrayIterator
      *
      * @param int   $offset
      * @param mixed $value
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]
@@ -38,6 +39,7 @@ class ElementList extends ArrayIterator
      * This method just forwards the request to the inner iterator
      *
      * @param int $offset
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/lib/Node.php
+++ b/lib/Node.php
@@ -212,6 +212,7 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      *
      * @param int   $offset
      * @param mixed $value
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]
@@ -234,6 +235,7 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * This method just forwards the request to the inner iterator
      *
      * @param int $offset
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/lib/Node.php
+++ b/lib/Node.php
@@ -212,6 +212,7 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      *
      * @param int   $offset
      * @param mixed $value
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -233,6 +234,7 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * This method just forwards the request to the inner iterator
      *
      * @param int $offset
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -457,6 +457,7 @@ abstract class Property extends Node
      *
      * @param string $name
      * @param mixed  $value
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
@@ -478,6 +479,7 @@ abstract class Property extends Node
      * Removes one or more parameters with the specified name.
      *
      * @param string $name
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($name)

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -457,6 +457,7 @@ abstract class Property extends Node
      *
      * @param string $name
      * @param mixed  $value
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]
@@ -479,6 +480,7 @@ abstract class Property extends Node
      * Removes one or more parameters with the specified name.
      *
      * @param string $name
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -299,6 +299,7 @@ class DateTime extends Property
      *
      * @param string $name
      * @param mixed  $value
+     *
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -299,6 +299,7 @@ class DateTime extends Property
      *
      * @param string $name
      * @param mixed  $value
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)


### PR DESCRIPTION
See #563.

This adds only phpdoc return types as real return types would not work for the earlier php versions this library supports.