### PR TITLE
Support concurrency of multiple RDATE together with RRULE directives.

### DIFF
--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -163,18 +163,29 @@ class EventIterator implements \Iterator
             $this->eventDuration = 0;
         }
 
+        $this->recurIterators = [];
+        $isRecurring = false;
+        if (isset($this->masterEvent->RRULE)) {
+            foreach ($this->masterEvent->RRULE as $rRule) {
+                $this->recurIterators[] = new RRuleIterator(
+                    $this->masterEvent->RRULE->getParts(),
+                    $this->startDate
+                );
+            }
+            $isRecurring = true;
+        }
         if (isset($this->masterEvent->RDATE)) {
-            $this->recurIterator = new RDateIterator(
-                $this->masterEvent->RDATE->getParts(),
-                $this->startDate
-            );
-        } elseif (isset($this->masterEvent->RRULE)) {
-            $this->recurIterator = new RRuleIterator(
-                $this->masterEvent->RRULE->getParts(),
-                $this->startDate
-            );
-        } else {
-            $this->recurIterator = new RRuleIterator(
+            foreach ($this->masterEvent->RDATE as $rDate) {
+                $this->recurIterators[] = new RDateIterator(
+                    $rDate->getParts(),
+                    $this->startDate,
+                    omitStart: $isRecurring
+                );
+                $isRecurring = true;
+            }
+        }
+        if (!$isRecurring) {
+            $this->recurIterators[] = new RRuleIterator(
                 [
                     'FREQ' => 'DAILY',
                     'COUNT' => 1,
@@ -313,7 +324,9 @@ class EventIterator implements \Iterator
     #[\ReturnTypeWillChange]
     public function rewind(): void
     {
-        $this->recurIterator->rewind();
+        foreach ($this->recurIterators as $iterator) {
+            $iterator->rewind();
+        }
         // re-creating overridden event index.
         $index = [];
         foreach ($this->overriddenEvents as $key => $event) {
@@ -350,14 +363,41 @@ class EventIterator implements \Iterator
             // We need to ask rruleparser for the next date.
             // We need to do this until we find a date that's not in the
             // exception list.
+            $candidates = [];
+            foreach ($this->recurIterators as $index => $iterator) {
+                if (!$iterator->valid()) {
+                    continue;
+                }
+                $candidates[$index] = $iterator->current()->getTimeStamp();
+            }
             do {
-                if (!$this->recurIterator->valid()) {
+                if (empty($candidates)) {
                     $nextDate = null;
                     break;
                 }
-                $nextDate = $this->recurIterator->current();
-                $this->recurIterator->next();
-            } while (isset($this->exceptions[$nextDate->getTimeStamp()]));
+                asort($candidates);
+                $nextIndex = array_key_first($candidates);
+                $nextDate = $this->recurIterators[$nextIndex]->current();
+                $nextStamp = $candidates[$nextIndex];
+
+                $isException = isset($this->exceptions[$nextStamp]);
+
+                // advance all iterators which match the current timestamp
+                foreach ($candidates as $index => $stamp) {
+                    if ($stamp > $nextStamp) {
+                        break;
+                    }
+                    $iterator = $this->recurIterators[$index];
+                    $iterator->next();
+                    if ($isException) {
+                        if ($iterator->valid()) {
+                            $candidates[$index] = $iterator->current()->getTimeStamp();
+                        } else {
+                            unset($candidates[$index]);
+                        }
+                    }
+                }
+            } while ($isException);
         }
 
         // $nextDate now contains what rrule thinks is the next one, but an
@@ -405,15 +445,20 @@ class EventIterator implements \Iterator
      */
     public function isInfinite(): bool
     {
-        return $this->recurIterator->isInfinite();
+        foreach ($this->recurIterators as $iterator) {
+            if ($iterator->isInfinite()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * RRULE parser.
      *
-     * @var RRuleIterator|RDateIterator
+     * @var array<int, RRuleIterator|RDateIterator>
      */
-    protected \Iterator $recurIterator;
+    protected array $recurIterators;
 
     /**
      * The duration, in seconds, of the master event.

--- a/tests/VObject/Recur/EventIterator/MultipleRDateRRuleTest.php
+++ b/tests/VObject/Recur/EventIterator/MultipleRDateRRuleTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sabre\VObject\Recur\EventIterator;
+
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
+
+/**
+ * This is a unit test for Issue #53.
+ */
+class MultipleRDateRRuleTest extends TestCase
+{
+    public function testExpand(): void
+    {
+        $input = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:2CD5887F7CF4600F7A3B1F8065099E40-240BDA7121B61224
+DTSTAMP;VALUE=DATE-TIME:20151014T110604Z
+CREATED;VALUE=DATE-TIME:20151014T110245Z
+LAST-MODIFIED;VALUE=DATE-TIME:20151014T110541Z
+DTSTART;VALUE=DATE-TIME;TZID=Europe/Berlin:20151025T020000
+DTEND;VALUE=DATE-TIME;TZID=Europe/Berlin:20151025T013000
+SUMMARY:Test
+SEQUENCE:2
+RRULE:FREQ=DAILY;UNTIL=20151027T225959Z;INTERVAL=1
+RDATE;VALUE=DATE-TIME;TZID=Europe/Berlin:20151018T020000,20151020T020000
+RDATE;VALUE=DATE-TIME;TZID=Europe/Berlin:20151015T020000,20151017T020000
+TRANSP:OPAQUE
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $vcal = Reader::read($input);
+        self::assertInstanceOf(VCalendar::class, $vcal);
+
+        $vcal = $vcal->expand(new \DateTime('2015-01-01'), new \DateTime('2015-12-01'));
+
+        $result = iterator_to_array($vcal->VEVENT);
+
+        $utc = new \DateTimeZone('UTC');
+        $expected = [
+            new \DateTimeImmutable('2015-10-15', $utc),
+            new \DateTimeImmutable('2015-10-17', $utc),
+            new \DateTimeImmutable('2015-10-18', $utc),
+            new \DateTimeImmutable('2015-10-20', $utc),
+            new \DateTimeImmutable('2015-10-25T01:00:00.000000+0000', $utc),
+            new \DateTimeImmutable('2015-10-26T01:00:00.000000+0000', $utc),
+            new \DateTimeImmutable('2015-10-27T01:00:00.000000+0000', $utc),
+        ];
+
+        $result = array_map(function ($ev) {return $ev->DTSTART->getDateTime(); }, $result);
+
+        self::assertCount(7, $result);
+
+        self::assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
This PR address #347 and its duplicate #700. The commit also adds a test. The idea is to maintain an array of iterators, compare their current values and pick the smallest one in next(). Then all iterators matching the timestamp value of the chosen DateTime are advanced, which the others which may be invalid or have their individual current values still ahead of time are kept at their position.

I have added a test (with one RRULE and RDATES which are placed "out of order").