### PR TITLE
feat(VCard): add getByTypes method (#717)

### DIFF
--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -410,6 +410,34 @@ class VCard extends VObject\Document
     }
 
     /**
+     * Returns a property with a specific TYPE value (ADR, TEL, or EMAIL).
+     *
+     * This function will return null if the exact property list does not exist.
+     *
+     * For example to get the property of `TEL;TYPE=HOME,CELL`
+     * you would call `getByTypes('TEL', ['HOME', 'CELL'])`
+     *
+     * @param string[] $types
+     *
+     * @return \ArrayAccess|array|null
+     */
+    public function getByTypes(string $propertyName, array $types)
+    {
+        $types = array_map('strtolower', $types);
+        foreach ($this->select($propertyName) as $field) {
+            if (isset($field['TYPE'])) {
+                $parts = array_map('strtolower', $field['TYPE']->getParts());
+
+                if (!array_diff($types, $parts) && !array_diff($parts, $types)) {
+                    return $field;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * This method should return a list of default property values.
      */
     protected function getDefaults(): array

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -147,6 +147,27 @@ VCF;
         self::assertNull($vcard->getByType('ADR', 'non-existent'));
     }
 
+    public function testGetByTypes(): void
+    {
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+TEL;TYPE=HOME,CELL:112233445566
+TEL;TYPE=WORK,cell:665544332211
+TEL;TYPE=WORK:7778889994455
+TEL;TYPE=EXTERNAL:555555555
+END:VCARD
+VCF;
+
+        $vcard = VObject\Reader::read($vcard);
+        self::assertEquals('112233445566', $vcard->getByTypes('TEL', ['home', 'cell'])->getValue());
+        self::assertEquals('665544332211', $vcard->getByTypes('TEL', ['work', 'cell'])->getValue());
+        self::assertEquals('7778889994455', $vcard->getByTypes('TEL', ['work'])->getValue());
+        self::assertEquals('555555555', $vcard->getByTypes('TEL', ['external'])->getValue());
+        self::assertNull($vcard->getByTypes('TEL', ['non-existent']));
+        self::assertNull($vcard->getByTypes('EMAIL', ['non-existent']));
+    }
+
     public function testPreferredNoPref(): void
     {
         $vcard = <<<VCF


### PR DESCRIPTION
In this PR I added a getByTypes method that gets an string array to select an exact property of a VCard.

It checks case insensitive and need to exactly match the types of the wanted property. 