### PR TITLE
Improve error checks in Mimedir parser

### DIFF
--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -276,4 +276,21 @@ EOF;
         $vevent = $mimeDir->parse($iCal);
         self::assertEquals('test', $vevent->VEVENT->{0}->getValue());
     }
+
+    public function testInvalidParameter(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Invalid Mimedir file. Line starting at 3: Missing parameter name for parameter value "value2"');
+        $vcard = <<<EOF
+BEGIN:VCARD
+VERSION:4.0
+FN;P1=value1; P2=value2:value
+UID:1234
+END:VCARD
+EOF;
+        $mimeDir = new MimeDir();
+        $vcard = $mimeDir->parse($vcard);
+
+        echo $vcard->serialize();
+    }
 }


### PR DESCRIPTION
The Mimedir parser has a general flaw which is it simply ignores tokens it doesn't recognize.

As an example, the following property is invalid according to the specifications, and should be rejected by the parser. 

`FN;P1=value1; P2=value2:value`

The problem is a whitespace in front of parameter name P2, which is not allowed according to the grammar described [here](https://datatracker.ietf.org/doc/html/rfc6350#section-3.3) . However, the current Mimedir parser do accept the line and furthermore misinterprets it to be on this format:

`FN;P1=value1,value2:value`

This pull request solves this specific problem by introducing the possibility to look back on the previous token parsed. Maybe it can be further improved by adding more checks. However a more general solution should possibly be preferred, I guess a complete rewrite of the parser could be the best solution.
