### PR TITLE
Removing attendee from scheduled recurring event should generate an EXDATE property 

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -479,7 +479,6 @@ class Broker
         }
 
         $messages = [];
-
         foreach ($attendees as $attendee) {
             // An organizer can also be an attendee. We should not generate any
             // messages for those.
@@ -892,6 +891,9 @@ class Broker
                     $timezone = $vevent->{'RECURRENCE-ID'}->getDateTime()->getTimeZone();
                 }
             }
+
+            $instances[$recurId] = $vevent;
+
             if (isset($vevent->ATTENDEE)) {
                 foreach ($vevent->ATTENDEE as $attendee) {
                     if ($this->scheduleAgentServerRules
@@ -930,7 +932,6 @@ class Broker
                         ];
                     }
                 }
-                $instances[$recurId] = $vevent;
             }
 
             foreach ($this->significantChangeProperties as $prop) {

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -435,8 +435,7 @@ DTSTAMP:20111005T133225Z
 …
 END:VAVAILABILITY
 END:VCALENDAR
-VCAL
-            ,
+VCAL,
             $properties
         );
     }
@@ -459,8 +458,7 @@ DTSTART:20111005T133225Z
 END:AVAILABLE
 END:VAVAILABILITY
 END:VCALENDAR
-VCAL
-            ,
+VCAL,
             $properties
         );
     }

--- a/tests/VObject/ITip/BrokerNewEventTest.php
+++ b/tests/VObject/ITip/BrokerNewEventTest.php
@@ -574,4 +574,60 @@ ICS;
 
         $this->parse(null, $message, [], 'mailto:strunk@example.org');
     }
+
+    public function testAttendeeRemoval(): void
+    {
+        $message = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART:20140811T220000Z
+DTEND:20140811T230000Z
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=White:mailto:white@example.org
+END:VEVENT
+BEGIN:VEVENT
+UID:foobar
+RECURRENCE-ID:20140812T220000Z
+DTSTART:20140812T220000Z
+DTEND:20140812T230000Z
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expectedMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:foobar
+RRULE:FREQ=DAILY
+DTSTART:20140811T220000Z
+DTEND:20140811T230000Z
+ORGANIZER;CN=Strunk:mailto:strunk@example.org
+ATTENDEE;CN=White;PARTSTAT=NEEDS-ACTION:mailto:white@example.org
+EXDATE:20140812T220000Z
+DTSTAMP:**ANY**
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $expected = [
+            [
+                'uid' => 'foobar',
+                'method' => 'REQUEST',
+                'component' => 'VEVENT',
+                'sender' => 'mailto:strunk@example.org',
+                'senderName' => 'Strunk',
+                'recipient' => 'mailto:white@example.org',
+                'recipientName' => 'White',
+                'message' => $expectedMessage,
+            ],
+        ];
+
+        $this->parse(null, $message, $expected, 'mailto:strunk@example.org');
+    }
 }

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -47,8 +47,7 @@ class XmlTest extends TestCase
   </components>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             // VERSION comes first because this is required by vCard 4.0.
             'VERSION:2.0'."\n".
@@ -270,8 +269,7 @@ XML;
 <icalendar xmlns="urn:ietf:params:xml:ns:icalendar-2.0">
  <vcalendar/>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'END:VCALENDAR'."\n"
         );
@@ -299,8 +297,7 @@ XML
   </components>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'BEGIN:VTIMEZONE'."\n".
             'END:VTIMEZONE'."\n".
@@ -340,8 +337,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'GEO:37.386013;-122.082932'."\n".
             'END:VCALENDAR'."\n"
@@ -367,8 +363,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'REQUEST-STATUS:2.0;Success'."\n".
             'END:VCALENDAR'."\n"
@@ -389,8 +384,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'REQUEST-STATUS:3.1;Invalid property value;DTSTART:96-Apr-01'."\n".
             'END:VCALENDAR'."\n"
@@ -411,8 +405,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'REQUEST-STATUS:2.8;Success\, repeating event ignored. Scheduled as a single'."\n".
             '  event.;RRULE:FREQ=WEEKLY\;INTERVAL=2'."\n".
@@ -433,8 +426,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'REQUEST-STATUS:4.1;Event conflict.  Date-time is busy.'."\n".
             'END:VCALENDAR'."\n"
@@ -455,8 +447,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'REQUEST-STATUS:3.7;Invalid calendar user;ATTENDEE:mailto:jsmith@example.com'."\n".
             'END:VCALENDAR'."\n"
@@ -480,8 +471,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'ATTACH:SGVsbG8gV29ybGQh'."\n".
             'END:VCALENDAR'."\n"
@@ -500,8 +490,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'ATTACH:SGVsbG8gV29ybGQh'."\n".
             'END:VCALENDAR'."\n"
@@ -528,8 +517,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'ATTENDEE;RSVP=true:mailto:cyrus@example.com'."\n".
             'END:VCALENDAR'."\n"
@@ -553,8 +541,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'ATTENDEE:mailto:cyrus@example.com'."\n".
             'END:VCALENDAR'."\n"
@@ -578,8 +565,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'DTSTART;VALUE=DATE:20110517'."\n".
             'END:VCALENDAR'."\n"
@@ -603,8 +589,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'DTSTART:20110517T120000'."\n".
             'END:VCALENDAR'."\n"
@@ -628,8 +613,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'DURATION:P1D'."\n".
             'END:VCALENDAR'."\n"
@@ -662,8 +646,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'FOO:42'."\n".
             'END:VCALENDAR'."\n"
@@ -681,8 +664,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'FOO:-42'."\n".
             'END:VCALENDAR'."\n"
@@ -709,8 +691,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'FREEBUSY:20110517T120000/P1H'."\n".
             'END:VCALENDAR'."\n"
@@ -731,8 +712,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'FREEBUSY:20110517T120000/20120517T120000'."\n".
             'END:VCALENDAR'."\n"
@@ -761,8 +741,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RRULE:FREQ=YEARLY;COUNT=5;BYDAY=-1SU;BYMONTH=10'."\n".
             'END:VCALENDAR'."\n"
@@ -786,8 +765,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'CALSCALE:GREGORIAN'."\n".
             'END:VCALENDAR'."\n"
@@ -811,8 +789,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'FOO:120000'."\n".
             'END:VCALENDAR'."\n"
@@ -836,8 +813,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'ATTACH:http://calendar.example.com'."\n".
             'END:VCALENDAR'."\n"
@@ -862,8 +838,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'TZOFFSETFROM:-0500'."\n".
             'END:VCALENDAR'."\n"
@@ -882,8 +857,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'TZOFFSETFROM:+0100'."\n".
             'END:VCALENDAR'."\n"
@@ -907,8 +881,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'X-PROPERTY:20110512T120000Z'."\n".
             'END:VCALENDAR'."\n"
@@ -931,8 +904,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'DTSTART;X-PARAM=PT30M:20110512T130000Z'."\n".
             'END:VCALENDAR'."\n"
@@ -953,8 +925,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE:20080205T191224Z'."\n".
             'END:VCALENDAR'."\n"
@@ -973,8 +944,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE:20080205T191224Z,20090205T191224Z'."\n".
             'END:VCALENDAR'."\n"
@@ -995,8 +965,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE:20081006'."\n".
             'END:VCALENDAR'."\n"
@@ -1016,8 +985,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE:20081006,20091006,20101006'."\n".
             'END:VCALENDAR'."\n"
@@ -1046,8 +1014,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE;TZID=US/Eastern;VALUE=PERIOD:20060102T150000/PT2H'."\n".
             'END:VCALENDAR'."\n"
@@ -1077,8 +1044,7 @@ XML
   </properties>
  </vcalendar>
 </icalendar>
-XML
-            ,
+XML,
             'BEGIN:VCALENDAR'."\n".
             'RDATE;TZID=US/Eastern;VALUE=PERIOD:20060102T150000/PT2H,20080102T150000/PT1'."\n".
             ' H'."\n".
@@ -1108,8 +1074,7 @@ XML
   </n>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'FN:J. Doe'."\n".
@@ -1149,8 +1114,7 @@ XML
   <x1:a href="http://www.example.com" xmlns:x1="http://www.w3.org/1999/xhtml">My web page!</x1:a>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'FN:J. Doe'."\n".
@@ -1183,8 +1147,7 @@ XML
   </tel>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TEL;TYPE="voice,video":tel:+1-555-555-555'."\n".
@@ -1207,8 +1170,7 @@ XML
   </tel>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TEL;TYPE="voice,video":tel:+1-555-555-555'."\n".
@@ -1244,8 +1206,7 @@ XML
   </group>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TEL:tel:+1-555-555-556'."\n".
@@ -1276,8 +1237,7 @@ XML
   </x-my-prop>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'X-MY-PROP;PREF=1:value goes here'."\n".
@@ -1300,8 +1260,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:20150128'."\n".
@@ -1324,8 +1283,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:2015-01'."\n".
@@ -1348,8 +1306,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:--01'."\n".
@@ -1372,8 +1329,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:--0128'."\n".
@@ -1396,8 +1352,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28'."\n".
@@ -1420,8 +1375,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:13'."\n".
@@ -1444,8 +1398,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:1353'."\n".
@@ -1468,8 +1421,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:135301'."\n".
@@ -1492,8 +1444,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:-53'."\n".
@@ -1516,8 +1467,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:-5301'."\n".
@@ -1573,8 +1523,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:--01Z'."\n".
@@ -1597,8 +1546,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:--01+1234'."\n".
@@ -1621,8 +1569,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:20150128T13'."\n".
@@ -1645,8 +1592,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:--0128T13'."\n".
@@ -1669,8 +1615,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28T13'."\n".
@@ -1693,8 +1638,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28T1353'."\n".
@@ -1717,8 +1661,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28T135301'."\n".
@@ -1741,8 +1684,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28T13Z'."\n".
@@ -1765,8 +1707,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:---28T13+1234'."\n".
@@ -1789,8 +1730,7 @@ XML
   </source>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'SOURCE:ldap://ldap.example.com/cn=Babs%20Jensen\,%20o=Babsco\,%20c=US'."\n".
@@ -1813,8 +1753,7 @@ XML
   </kind>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'KIND:individual'."\n".
@@ -1837,8 +1776,7 @@ XML
   </fn>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'FN:Mr. John Q. Public\, Esq.'."\n".
@@ -1865,8 +1803,7 @@ XML
   </n>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'N:Stevenson;John;Philip\,Paul;Dr.;Jr.\,M.D.\,A.C.P.'."\n".
@@ -1890,8 +1827,7 @@ XML
   </nickname>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'NICKNAME:Jim,Jimmie'."\n".
@@ -1914,8 +1850,7 @@ XML
   </photo>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'PHOTO:http://www.example.com/pub/photos/jqpublic.gif'."\n".
@@ -1935,8 +1870,7 @@ XML
   </bday>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'BDAY:19531015T231000Z'."\n".
@@ -1956,8 +1890,7 @@ XML
   </anniversary>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'ANNIVERSARY:19960415'."\n".
@@ -1981,8 +1914,7 @@ XML
   </gender>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'GENDER:Jim;Jimmie'."\n".
@@ -2011,8 +1943,7 @@ XML
   </adr>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.A.'."\n".
@@ -2050,8 +1981,7 @@ XML
   </tel>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TEL;TYPE=home:tel:+33-01-23-45-67'."\n".
@@ -2073,8 +2003,7 @@ XML
   </tel>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TEL;TYPE=home:tel:+33-01-23-45-67'."\n".
@@ -2102,8 +2031,7 @@ XML
   </email>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'EMAIL;TYPE=work:jqpublic@xyz.example.com'."\n".
@@ -2131,8 +2059,7 @@ XML
   </impp>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'IMPP;PREF=1:xmpp:alice@example.com'."\n".
@@ -2163,8 +2090,7 @@ XML
   </lang>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'LANG;TYPE=work;PREF=2:en'."\n".
@@ -2187,8 +2113,7 @@ XML
   </tz>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TZ:Raleigh/North America'."\n".
@@ -2211,8 +2136,7 @@ XML
   </geo>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'GEO:geo:37.386013\,-122.082932'."\n".
@@ -2229,8 +2153,7 @@ XML
   </geo>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'GEO:geo:37.386013\,-122.082932'."\n".
@@ -2253,8 +2176,7 @@ XML
   </title>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'TITLE:Research Scientist'."\n".
@@ -2277,8 +2199,7 @@ XML
   </role>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'ROLE:Project Leader'."\n".
@@ -2301,8 +2222,7 @@ XML
   </logo>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'LOGO:http://www.example.com/pub/logos/abccorp.jpg'."\n".
@@ -2327,8 +2247,7 @@ XML
   </org>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'ORG:ABC\, Inc.;North American Division;Marketing'."\n".
@@ -2351,8 +2270,7 @@ XML
   </member>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'MEMBER:urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af'."\n".
@@ -2378,8 +2296,7 @@ XML
   </member>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'MEMBER:mailto:subscriber1@example.com'."\n".
@@ -2410,8 +2327,7 @@ XML
   </related>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'RELATED;TYPE=friend:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'."\n".
@@ -2437,8 +2353,7 @@ XML
   </categories>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'CATEGORIES:INTERNET,IETF,INDUSTRY,INFORMATION TECHNOLOGY'."\n".
@@ -2461,8 +2376,7 @@ XML
   </note>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'NOTE:Foo\, bar'."\n".
@@ -2485,8 +2399,7 @@ XML
   </prodid>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'PRODID:-//ONLINE DIRECTORY//NONSGML Version 1//EN'."\n".
@@ -2506,8 +2419,7 @@ XML
   </rev>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'REV:19951031T222710Z'."\n".
@@ -2530,8 +2442,7 @@ XML
   </sound>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'SOUND:CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com'."\n".
@@ -2548,8 +2459,7 @@ XML
   </sound>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'SOUND:CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com'."\n".
@@ -2572,8 +2482,7 @@ XML
   </uid>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'UID:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'."\n".
@@ -2597,8 +2506,7 @@ XML
   </clientpidmap>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'CLIENTPIDMAP:1;urn:uuid:3df403f4-5924-4bb7-b077-3c711d9eb34b'."\n".
@@ -2621,8 +2529,7 @@ XML
   </url>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'URL:http://example.org/restaurant.french/~chezchic.html'."\n".
@@ -2641,8 +2548,7 @@ XML
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
  <vcard/>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'END:VCARD'."\n"
@@ -2669,8 +2575,7 @@ XML
   </key>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'KEY;MEDIATYPE=application/pgp-keys:ftp://example.com/keys/jdoe'."\n".
@@ -2698,8 +2603,7 @@ XML
   </fburl>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'FBURL;PREF=1:http://www.example.com/busy/janedoe'."\n".
@@ -2722,8 +2626,7 @@ XML
   </caladruri>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'CALADRURI:http://example.com/calendar/jdoe'."\n".
@@ -2751,8 +2654,7 @@ XML
   </caluri>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'CALURI;PREF=1:http://cal.example.com/calA'."\n".
@@ -2775,8 +2677,7 @@ XML
   </capuri>
  </vcard>
 </vcards>
-XML
-            ,
+XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
             'CAPURI:http://cap.example.com/capA'."\n".


### PR DESCRIPTION
In the (special) case where an organizer creates a recurrent event with only one attendee and removes that attendee from one of the instances, an iTip message with an EXDATE property should be created. Currently, the EXDATE is not correctly inserted in the iTip message, this pull request fixes that.