### PR TITLE
fix(itip): handle null old calendar/event

### DIFF
--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -679,7 +679,7 @@ class Broker
         // We only need to do that though, if the master event is not declined.
         if (isset($instances['master']) && 'DECLINED' !== $instances['master']['newstatus']) {
             foreach ($eventInfo['exdate'] as $exDate) {
-                if (!in_array($exDate, $oldEventInfo['exdate'])) {
+                if (!in_array($exDate, $oldEventInfo['exdate'] ?? [])) {
                     if (isset($instances[$exDate])) {
                         $instances[$exDate]['newstatus'] = 'DECLINED';
                     } else {

--- a/tests/VObject/ITip/BrokerAttendeeReplyTest.php
+++ b/tests/VObject/ITip/BrokerAttendeeReplyTest.php
@@ -1256,4 +1256,73 @@ ICS,
 
         $this->parse($oldMessage, $newMessage, $expected);
     }
+
+    /**
+     * Test that adding EXDATE entries when oldEventInfo doesn't have exdate
+     * (e.g., when updating a newly created event) doesn't cause a TypeError.
+     *
+     * This tests the scenario where an attendee receives a new recurring event
+     * invitation with EXDATE entries already present. Since there's no old calendar,
+     * oldEventInfo is initialized with only minimal keys and lacks 'exdate'.
+     */
+    public function testAddExdateWithoutPreviousExdate(): void
+    {
+        // No old message - this is a new event invitation
+        $oldMessage = null;
+
+        // New message: recurring event with EXDATE already present
+        $newMessage = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:foobar
+SEQUENCE:1
+DTSTART:20140811T200000Z
+RRULE:FREQ=WEEKLY
+ORGANIZER:mailto:organizer@example.org
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:one@example.org
+EXDATE:20140818T200000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+        $version = \Sabre\VObject\Version::VERSION;
+        $expected = [
+            [
+                'uid' => 'foobar',
+                'method' => 'REPLY',
+                'component' => 'VEVENT',
+                'sender' => 'mailto:one@example.org',
+                'senderName' => null,
+                'recipient' => 'mailto:organizer@example.org',
+                'recipientName' => null,
+                'message' => <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject $version//EN
+CALSCALE:GREGORIAN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:foobar
+DTSTAMP:**ANY**
+SEQUENCE:1
+DTSTART:20140811T200000Z
+ORGANIZER:mailto:organizer@example.org
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:one@example.org
+END:VEVENT
+BEGIN:VEVENT
+UID:foobar
+DTSTAMP:**ANY**
+SEQUENCE:1
+DTSTART:20140818T200000Z
+RECURRENCE-ID:20140818T200000Z
+ORGANIZER:mailto:organizer@example.org
+ATTENDEE;PARTSTAT=DECLINED:mailto:one@example.org
+END:VEVENT
+END:VCALENDAR
+ICS,
+            ],
+        ];
+        $this->parse($oldMessage, $newMessage, $expected);
+    }
 }


### PR DESCRIPTION
Fixes `TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given` by coercing the possible null value to an empty array.

Discovered by our Sentry:

<img width="871" height="476" alt="Bildschirmfoto vom 2026-03-19 18-26-04" src="https://github.com/user-attachments/assets/758ee127-2dbb-4385-bcc0-76a9be596202" />
