### PR TITLE
[4.5] chore: prepare release 4.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+4.5.9 (2026-05-31)
+------------------
+* #759 fix(itip): handle null old calendar/event (@ChristophWurst)
+
 4.5.8 (2026-01-12)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.5.8';
+    public const VERSION = '4.5.9';
 }


### PR DESCRIPTION
This release just contains one bugfix PR.

I will then make a 4.6.0 release that contains things that have new functionality and minor changes.