### PR TITLE
chore: changelogs for 4.5.9 and 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ChangeLog
 =========
 
+4.6.0 (2026-05-31)
+------------------
+* #718 feat(VCard): add getByTypes method (@JimKnoxx)
+* #756 fix: Update deprecated timezone names (@ralflang)
+
+4.5.9 (2026-05-31)
+------------------
+* #759 fix(itip): handle null old calendar/event (@ChristophWurst)
+
 4.5.8 (2026-01-12)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,5 +14,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.5.8';
+    public const VERSION = '4.6.0';
 }


### PR DESCRIPTION
Forward port the changelogs for the 4.5.9 and 4.6.0 releases to master.

After this (tomorrow), I will then work out what to do about dropping support for PHP 7.*, 8.0 and 8.1.

The code in master has a lot of changes for later PHP (return type declarations, parameter types, documentation of arrayh shapes for phpstan, and so on. Maybe it will be best to do the PHP version support changes only in master, and to release a major version from master.