### PR TITLE
feat: preserve UTC 'Z' indicator in Period JSON serialization

### DIFF
--- a/lib/Property/ICalendar/Period.php
+++ b/lib/Property/ICalendar/Period.php
@@ -70,6 +70,11 @@ class Period extends Property
         parent::setJsonValue($value);
     }
 
+    public function appendUtc(string $strDate)
+    {
+        return !str_ends_with($strDate, 'Z') ? '' : 'Z';
+    }
+
     /**
      * Returns the value, in the format it should be encoded for json.
      *
@@ -83,19 +88,19 @@ class Period extends Property
         foreach ($this->getParts() as $item) {
             [$start, $end] = explode('/', (string) $item, 2);
 
-            $start = DateTimeParser::parseDateTime($start);
+            $startDt = DateTimeParser::parseDateTime($start)->format('Y-m-d\\TH:i:s').$this->appendUtc($start);
 
             // This is a duration value.
             if ('P' === $end[0]) {
                 $return[] = [
-                    $start->format('Y-m-d\\TH:i:s'),
+                    $startDt,
                     $end,
                 ];
             } else {
-                $end = DateTimeParser::parseDateTime($end);
+                $endDt = DateTimeParser::parseDateTime($end)->format('Y-m-d\\TH:i:s').$this->appendUtc($end);
                 $return[] = [
-                    $start->format('Y-m-d\\TH:i:s'),
-                    $end->format('Y-m-d\\TH:i:s'),
+                    $startDt,
+                    $endDt,
                 ];
             }
         }

--- a/tests/VObject/JCalTest.php
+++ b/tests/VObject/JCalTest.php
@@ -97,7 +97,7 @@ class JCalTest extends TestCase
                             'sequence', new \stdClass(), 'integer', 5,
                         ],
                         [
-                            'freebusy', new \stdClass(), 'period',  ['2013-05-26T21:02:13', 'PT1H'], ['2013-06-26T12:00:00', '2013-06-26T13:00:00'],
+                            'freebusy', new \stdClass(), 'period',  ['2013-05-26T21:02:13Z', 'PT1H'], ['2013-06-26T12:00:00Z', '2013-06-26T13:00:00Z'],
                         ],
                         [
                             'url', new \stdClass(), 'uri', 'http://example.org/',

--- a/tests/VObject/Parser/JsonTest.php
+++ b/tests/VObject/Parser/JsonTest.php
@@ -261,7 +261,7 @@ VCF;
                             'sequence', new \stdClass(), 'integer', 5,
                         ],
                         [
-                            'freebusy', new \stdClass(), 'period',  ['2013-05-26T21:02:13', 'PT1H'], ['2013-06-26T12:00:00', '2013-06-26T13:00:00'],
+                            'freebusy', new \stdClass(), 'period',  ['2013-05-26T21:02:13Z', 'PT1H'], ['2013-06-26T12:00:00Z', '2013-06-26T13:00:00Z'],
                         ],
                         [
                             'url', new \stdClass(), 'uri', 'http://example.org/',
@@ -330,7 +330,7 @@ ATTENDEE:mailto:armin@example.org
 ATTENDEE;CN=Dominik;PARTSTAT=DECLINED:mailto:dominik@example.org
 GEO:51.96668;7.61876
 SEQUENCE:5
-FREEBUSY:20130526T210213/PT1H,20130626T120000/20130626T130000
+FREEBUSY:20130526T210213Z/PT1H,20130626T120000Z/20130626T130000Z
 URL;VALUE=URI:http://example.org/
 TZOFFSETFROM:+0500
 RRULE:FREQ=WEEKLY;BYDAY=MO,TU

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -684,7 +684,7 @@ XML,
   <properties>
    <freebusy>
     <period>
-     <start>2011-05-17T12:00:00</start>
+     <start>2011-05-17T12:00:00Z</start>
      <duration>P1H</duration>
     </period>
    </freebusy>
@@ -693,7 +693,7 @@ XML,
 </icalendar>
 XML,
             'BEGIN:VCALENDAR'."\n".
-            'FREEBUSY:20110517T120000/P1H'."\n".
+            'FREEBUSY:20110517T120000Z/P1H'."\n".
             'END:VCALENDAR'."\n"
         );
 
@@ -705,8 +705,8 @@ XML,
   <properties>
    <freebusy>
     <period>
-     <start>2011-05-17T12:00:00</start>
-     <end>2012-05-17T12:00:00</end>
+     <start>2011-05-17T12:00:00Z</start>
+     <end>2012-05-17T12:00:00Z</end>
     </period>
    </freebusy>
   </properties>
@@ -714,7 +714,7 @@ XML,
 </icalendar>
 XML,
             'BEGIN:VCALENDAR'."\n".
-            'FREEBUSY:20110517T120000/20120517T120000'."\n".
+            'FREEBUSY:20110517T120000Z/20120517T120000Z'."\n".
             'END:VCALENDAR'."\n"
         );
     }

--- a/tests/VObject/Property/ICalendar/DateTimeTest.php
+++ b/tests/VObject/Property/ICalendar/DateTimeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\InvalidDataException;
@@ -320,12 +321,41 @@ class DateTimeTest extends TestCase
         self::assertEquals("DTSTART;VALUE=DATE:20130607\r\n", $dtStart->serialize());
     }
 
-    public function testValidate(): void
+    public static function validateDateTimeProvider(): array
     {
-        $exDate = $this->vcal->createProperty('EXDATE', '-00011130T143000Z');
+        return [
+            [
+                '-00011130T143000Z',
+                1,
+                3,
+            ],
+            [
+                '20260627T100000',
+                0,
+                0,
+            ],
+            [
+                '20260627T100000Z',
+                0,
+                0,
+            ],
+            [
+                '20260627T100000Z+0200',
+                1,
+                3,
+            ],
+        ];
+    }
+
+    #[DataProvider('validateDateTimeProvider')]
+    public function testValidate(string $invalidDateTime, int $expectedMessageCount, int $expectedMessageLevel): void
+    {
+        $exDate = $this->vcal->createProperty('EXDATE', $invalidDateTime);
         $messages = $exDate->validate();
-        self::assertCount(1, $messages);
-        self::assertEquals(3, $messages[0]['level']);
+        self::assertCount($expectedMessageCount, $messages);
+        if ($expectedMessageCount > 0) {
+            self::assertEquals($expectedMessageLevel, $messages[0]['level']);
+        }
     }
 
     /**


### PR DESCRIPTION
When serializing PERIOD values to JSON (for jCal format), preserve the 'Z' timezone indicator for UTC datetimes. This ensures FREEBUSY periods maintain explicit UTC designation, avoiding timezone ambiguity.

Without this change:
  FREEBUSY:20120226T230000Z/20120226T230000Z
  => serializes to: ["2012-02-26T23:00:00", "2012-02-26T23:00:00"]

With this change:
  FREEBUSY:20120226T230000Z/20120226T230000Z
  => serializes to: ["2012-02-26T23:00:00Z", "2012-02-26T23:00:00Z"]

This behavior is consistent with RFC 5545 which requires UTC times to be designated with the 'Z' suffix.

Related: https://github.com/sabre-io/vobject/issues/411