### PR TITLE
fix: minor code fixes

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -806,7 +806,7 @@ class RRuleIterator implements \Iterator
                 case 'BYDAY':
                     $value = (array) $value;
                     foreach ($value as $part) {
-                        if (!preg_match('#^  (-|\+)? ([1-5])? (MO|TU|WE|TH|FR|SA|SU) $# xi', (string) $part)) {
+                        if (!preg_match('#^  (-|\+)? ([1-5])? (MO|TU|WE|TH|FR|SA|SU) $#xi', (string) $part)) {
                             throw new InvalidDataException('Invalid part in BYDAY clause: '.$part);
                         }
                     }
@@ -946,7 +946,7 @@ class RRuleIterator implements \Iterator
                     $byMonthDayResults[] = $monthDay;
                 } else {
                     // Negative values
-                    $byMonthDayResults[] = $startDate->format('t') + 1 + $monthDay;
+                    $byMonthDayResults[] = (int) $startDate->format('t') + 1 + $monthDay;
                 }
             }
         }


### PR DESCRIPTION
Modifiers at the end of a regex should not have whitespace before them. Change "# xi" to just "#xi".

Date format "t" returns a string that is the numbers of days in the month. Explicitly cast it to int when using it in a calculation.

These were two minor things pointed out by my editor. Existing tests will cover the changes here. There is no actual bug being fixed.