### PR TITLE
chore: refactor to declare more types

### DIFF
--- a/lib/Component/VAlarm.php
+++ b/lib/Component/VAlarm.php
@@ -32,7 +32,7 @@ class VAlarm extends VObject\Component
     public function getEffectiveTriggerTime(): \DateTimeImmutable
     {
         $trigger = $this->TRIGGER;
-        if (!isset($trigger['VALUE']) || ($trigger['VALUE'] && 'DURATION' === strtoupper((string) $trigger['VALUE']))) {
+        if (!isset($trigger['VALUE']) || ('DURATION' === strtoupper((string) $trigger['VALUE']))) {
             $triggerDuration = VObject\DateTimeParser::parseDuration($this->TRIGGER);
             $related = (isset($trigger['RELATED']) && 'END' === strtoupper($trigger['RELATED'])) ? 'END' : 'START';
 

--- a/lib/ITip/Broker.php
+++ b/lib/ITip/Broker.php
@@ -396,7 +396,7 @@ class Broker
             }
         }
 
-        if (!$masterObject) {
+        if (null === $masterObject) {
             // No master object, we can't add new instances.
             return null;
         }

--- a/lib/Node.php
+++ b/lib/Node.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sabre\VObject;
 
 use Sabre\Xml;
@@ -62,17 +64,12 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
     /**
      * This method returns an array, with the representation as it should be
      * encoded in JSON. This is used to create jCard or jCal documents.
-     *
-     * @return array|string
      */
-    #[\ReturnTypeWillChange]
-    abstract public function jsonSerialize();
+    abstract public function jsonSerialize(): array|string|null;
 
     /**
      * This method serializes the data into XML. This is used to create xCard or
      * xCal documents.
-     *
-     * @param Xml\Writer $writer XML writer
      */
     abstract public function xmlSerialize(Xml\Writer $writer): void;
 
@@ -93,8 +90,7 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
     /**
      * Returns the iterator for this object.
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator(): ?ElementList
+    public function getIterator(): ElementList
     {
         if (!is_null($this->iterator)) {
             return $this->iterator;
@@ -143,7 +139,6 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
     /**
      * Returns the number of elements.
      */
-    #[\ReturnTypeWillChange]
     public function count(): int
     {
         $it = $this->getIterator();
@@ -159,11 +154,8 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * Checks if an item exists through ArrayAccess.
      *
      * This method just forwards the request to the inner iterator
-     *
-     * @param int $offset
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         $iterator = $this->getIterator();
 
@@ -174,11 +166,8 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * Gets an item through ArrayAccess.
      *
      * This method just forwards the request to the inner iterator
-     *
-     * @param int $offset
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $iterator = $this->getIterator();
 
@@ -189,11 +178,8 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * Sets an item through ArrayAccess.
      *
      * This method just forwards the request to the inner iterator
-     *
-     * @param int $offset
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, $value): void
     {
         $iterator = $this->getIterator();
         $iterator->offsetSet($offset, $value);
@@ -210,11 +196,8 @@ abstract class Node implements \IteratorAggregate, \ArrayAccess, \Countable, \Js
      * Sets an item through ArrayAccess.
      *
      * This method just forwards the request to the inner iterator
-     *
-     * @param int $offset
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         $iterator = $this->getIterator();
         $iterator->offsetUnset($offset);

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sabre\VObject;
 
 use Sabre\Xml;
@@ -32,19 +34,15 @@ class Parameter extends Node implements \Stringable
 
     /**
      * Parameter value.
-     *
-     * @var string|array|null
      */
-    protected $value;
+    protected array|string|null $value = null;
 
     /**
      * Sets up the object.
      *
      * It's recommended to use the create:: factory method instead.
-     *
-     * @param string|array|null $value
      */
-    public function __construct(Document $root, ?string $name, $value = null)
+    public function __construct(Document $root, ?string $name, array|string|null $value = null)
     {
         $this->root = $root;
         if (is_null($name)) {
@@ -61,7 +59,9 @@ class Parameter extends Node implements \Stringable
             $this->noName = false;
             $this->name = strtoupper($value);
         } else {
-            $this->setValue($value);
+            if (null !== $value) {
+                $this->setValue($value);
+            }
         }
     }
 
@@ -88,10 +88,8 @@ class Parameter extends Node implements \Stringable
      * Updates the current value.
      *
      * This may be either a single, or multiple strings in an array.
-     *
-     * @param string|array $value
      */
-    public function setValue($value): void
+    public function setValue(array|string $value): void
     {
         $this->value = $value;
     }
@@ -140,10 +138,8 @@ class Parameter extends Node implements \Stringable
      *
      * If the argument is specified as an array, all items will be added to the
      * parameter value list.
-     *
-     * @param string|array $part
      */
-    public function addValue($part): void
+    public function addValue(array|string $part): void
     {
         if (is_null($this->value)) {
             $this->value = $part;
@@ -206,7 +202,7 @@ class Parameter extends Node implements \Stringable
                 // But we've found that iCal (7.0, shipped with OSX 10.9)
                 // severely trips on + characters not being quoted, so we
                 // added + as well.
-                if (!preg_match('#(?: [\n":;\^,\+] )#x', $item)) {
+                if (!preg_match('#(?: [\n":;\^,\+] )#x', (string) $item)) {
                     return $out.$item;
                 }
                 // Enclosing in double-quotes, and using RFC6868 for encoding any
@@ -228,11 +224,8 @@ class Parameter extends Node implements \Stringable
     /**
      * This method returns an array, with the representation as it should be
      * encoded in JSON. This is used to create jCard or jCal documents.
-     *
-     * @return array|string|null
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array|string|null
     {
         return $this->value;
     }
@@ -240,8 +233,6 @@ class Parameter extends Node implements \Stringable
     /**
      * This method serializes the data into XML. This is used to create xCard or
      * xCal documents.
-     *
-     * @param Xml\Writer $writer XML writer
      */
     public function xmlSerialize(Xml\Writer $writer): void
     {
@@ -261,7 +252,6 @@ class Parameter extends Node implements \Stringable
     /**
      * Returns the iterator for this object.
      */
-    #[\ReturnTypeWillChange]
     public function getIterator(): ElementList
     {
         if (!is_null($this->iterator)) {

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -362,17 +362,16 @@ abstract class Property extends Node implements \Stringable
     /**
      * Checks if an array element exists.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         if (is_int($offset)) {
             return parent::offsetExists($offset);
         }
 
-        $offset = strtoupper($offset);
+        $offset = strtoupper((string) $offset);
 
         foreach ($this->parameters as $parameter) {
-            if ($parameter->name == $offset) {
+            if ($parameter->name === $offset) {
                 return true;
             }
         }

--- a/tests/VObject/ITip/BrokerTester.php
+++ b/tests/VObject/ITip/BrokerTester.php
@@ -53,11 +53,12 @@ abstract class BrokerTester extends TestCase
      * @throws NoInstancesException
      * @throws InvalidDataException
      */
-    public function process($input, $existingObject = null, $expected = false): void
+    public function process(string $input, ?string $existingObject = null, bool|string|null $expected = false): void
     {
         $version = Version::VERSION;
 
         $vcal = Reader::read($input);
+        self::assertNotNull($vcal);
 
         $mainComponent = new VEvent($vcal, 'VEVENT');
         foreach ($vcal->getComponents() as $nextComponent) {
@@ -90,6 +91,7 @@ abstract class BrokerTester extends TestCase
                 $existingObject
             );
             $existingObject = Reader::read($existingObject);
+            self::assertNotNull($existingObject, 'existingObject could not be read');
         }
 
         $result = $broker->processMessage($message, $existingObject);
@@ -99,6 +101,8 @@ abstract class BrokerTester extends TestCase
 
             return;
         }
+
+        self::assertNotNull($result, 'processMessage returned null');
 
         self::assertVObjectEqualsVObject(
             $expected,

--- a/tests/VObject/ParameterTest.php
+++ b/tests/VObject/ParameterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sabre\VObject;
 
 use PHPUnit\Framework\TestCase;
@@ -30,17 +32,17 @@ class ParameterTest extends TestCase
         $cal = new Component\VCalendar();
 
         $param = new Parameter($cal, 'name', null);
-        $param->addValue(1);
+        $param->addValue('1');
         self::assertEquals([1], $param->getParts());
 
         $param->setParts([1, 2]);
         self::assertEquals([1, 2], $param->getParts());
 
-        $param->addValue(3);
+        $param->addValue('3');
         self::assertEquals([1, 2, 3], $param->getParts());
 
-        $param->setValue(4);
-        $param->addValue(5);
+        $param->setValue('4');
+        $param->addValue('5');
         self::assertEquals([4, 5], $param->getParts());
     }
 

--- a/tests/VObject/Parser/JsonTest.php
+++ b/tests/VObject/Parser/JsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sabre\VObject\Parser;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Trying some changes to type declarations now that PHP 8.2 is the minimum.

I thought that it might be easy to remove lots of `ReturnTypeWillChange`.
But it turns out to not always be simple. See a few comments below.