### PR TITLE
Adjust DataProvider test code 

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -13,6 +14,7 @@ return RectorConfig::configure()
     // uncomment to reach your current PHP version
     ->withPhpSets(false, true)
     ->withRules([
+        AddParamArrayDocblockFromDataProviderRector::class,
         DataProviderAnnotationToAttributeRector::class,
     ])
     ->withTypeCoverageLevel(0)

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -11,6 +12,9 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     ->withPhpSets(false, true)
+    ->withRules([
+        DataProviderAnnotationToAttributeRector::class,
+    ])
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/tests/VObject/CliTest.php
+++ b/tests/VObject/CliTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -280,7 +281,7 @@ VCF;
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideFormats')]
+    #[DataProvider('provideFormats')]
     public function testConvertDefaultFormats($inputFilename, $outputFilename, $format): void
     {
         $triggeredWarning = null;

--- a/tests/VObject/CliTest.php
+++ b/tests/VObject/CliTest.php
@@ -280,9 +280,7 @@ VCF;
         ];
     }
 
-    /**
-     * @dataProvider provideFormats
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFormats')]
     public function testConvertDefaultFormats($inputFilename, $outputFilename, $format): void
     {
         $triggeredWarning = null;

--- a/tests/VObject/Component/VAlarmTest.php
+++ b/tests/VObject/Component/VAlarmTest.php
@@ -2,13 +2,14 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\InvalidDataException;
 use Sabre\VObject\Reader;
 
 class VAlarmTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
+    #[DataProvider('timeRangeTestData')]
     public function testInTimeRange(VAlarm $valarm, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $valarm->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VAlarmTest.php
+++ b/tests/VObject/Component/VAlarmTest.php
@@ -8,9 +8,7 @@ use Sabre\VObject\Reader;
 
 class VAlarmTest extends TestCase
 {
-    /**
-     * @dataProvider timeRangeTestData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
     public function testInTimeRange(VAlarm $valarm, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $valarm->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -10,9 +10,7 @@ class VCalendarTest extends TestCase
 {
     use VObject\PHPUnitAssertions;
 
-    /**
-     * @dataProvider expandData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('expandData')]
     public function testExpand(string $input, string $output, string $timeZone = 'UTC', string $start = '2011-12-01', string $end = '2011-12-31'): void
     {
         $vcal = VObject\Reader::read($input);

--- a/tests/VObject/Component/VCalendarTest.php
+++ b/tests/VObject/Component/VCalendarTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 use Sabre\VObject\InvalidDataException;
@@ -10,7 +11,7 @@ class VCalendarTest extends TestCase
 {
     use VObject\PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('expandData')]
+    #[DataProvider('expandData')]
     public function testExpand(string $input, string $output, string $timeZone = 'UTC', string $start = '2011-12-01', string $end = '2011-12-31'): void
     {
         $vcal = VObject\Reader::read($input);

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -2,12 +2,13 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 
 class VCardTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('validateData')]
+    #[DataProvider('validateData')]
     public function testValidate(string $input, array $expectedWarnings, string $expectedRepairedOutput): void
     {
         $vcard = VObject\Reader::read($input);

--- a/tests/VObject/Component/VCardTest.php
+++ b/tests/VObject/Component/VCardTest.php
@@ -7,9 +7,7 @@ use Sabre\VObject;
 
 class VCardTest extends TestCase
 {
-    /**
-     * @dataProvider validateData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('validateData')]
     public function testValidate(string $input, array $expectedWarnings, string $expectedRepairedOutput): void
     {
         $vcard = VObject\Reader::read($input);

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -2,11 +2,12 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class VEventTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
+    #[DataProvider('timeRangeTestData')]
     public function testInTimeRange(VEvent $vevent, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vevent->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -6,9 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class VEventTest extends TestCase
 {
-    /**
-     * @dataProvider timeRangeTestData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
     public function testInTimeRange(VEvent $vevent, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vevent->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VJournalTest.php
+++ b/tests/VObject/Component/VJournalTest.php
@@ -7,9 +7,7 @@ use Sabre\VObject\Reader;
 
 class VJournalTest extends TestCase
 {
-    /**
-     * @dataProvider timeRangeTestData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
     public function testInTimeRange(VJournal $vtodo, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vtodo->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VJournalTest.php
+++ b/tests/VObject/Component/VJournalTest.php
@@ -2,12 +2,13 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 class VJournalTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
+    #[DataProvider('timeRangeTestData')]
     public function testInTimeRange(VJournal $vtodo, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vtodo->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VTodoTest.php
+++ b/tests/VObject/Component/VTodoTest.php
@@ -2,12 +2,13 @@
 
 namespace Sabre\VObject\Component;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Reader;
 
 class VTodoTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
+    #[DataProvider('timeRangeTestData')]
     public function testInTimeRange(VTodo $vtodo, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vtodo->isInTimeRange($start, $end));

--- a/tests/VObject/Component/VTodoTest.php
+++ b/tests/VObject/Component/VTodoTest.php
@@ -7,9 +7,7 @@ use Sabre\VObject\Reader;
 
 class VTodoTest extends TestCase
 {
-    /**
-     * @dataProvider timeRangeTestData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timeRangeTestData')]
     public function testInTimeRange(VTodo $vtodo, \DateTime $start, \DateTime $end, bool $outcome): void
     {
         self::assertEquals($outcome, $vtodo->isInTimeRange($start, $end));

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -458,9 +458,7 @@ class ComponentTest extends TestCase
         $comp->remove($prop);
     }
 
-    /**
-     * @dataProvider ruleData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ruleData')]
     public function testValidateRules(array $componentList, int $errorCount): void
     {
         $vcard = new VCard();

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -458,6 +458,9 @@ class ComponentTest extends TestCase
         $comp->remove($prop);
     }
 
+    /**
+     * @param string[] $componentList
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('ruleData')]
     public function testValidateRules(array $componentList, int $errorCount): void
     {

--- a/tests/VObject/ComponentTest.php
+++ b/tests/VObject/ComponentTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VCard;
@@ -461,7 +462,7 @@ class ComponentTest extends TestCase
     /**
      * @param string[] $componentList
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('ruleData')]
+    #[DataProvider('ruleData')]
     public function testValidateRules(array $componentList, int $errorCount): void
     {
         $vcard = new VCard();

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -166,6 +166,9 @@ class DateTimeParserTest extends TestCase
         DateTimeParser::parseDate('20101331');
     }
 
+    /**
+     * @param array<string, int|string|null> $output
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('vcardDates')]
     public function testVCardDate(string $input, array $output): void
     {

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeParserTest extends TestCase
@@ -169,7 +170,7 @@ class DateTimeParserTest extends TestCase
     /**
      * @param array<string, int|string|null> $output
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('vcardDates')]
+    #[DataProvider('vcardDates')]
     public function testVCardDate(string $input, array $output): void
     {
         self::assertEquals(

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -166,9 +166,7 @@ class DateTimeParserTest extends TestCase
         DateTimeParser::parseDate('20101331');
     }
 
-    /**
-     * @dataProvider vcardDates
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('vcardDates')]
     public function testVCardDate(string $input, array $output): void
     {
         self::assertEquals(

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -109,9 +109,7 @@ VCF;
         ];
     }
 
-    /**
-     * @dataProvider provideEmptyParserInput
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEmptyParserInput')]
     public function testParseEmpty($input, $expectedExceptionMessage): void
     {
         $this->expectException(ParseException::class);
@@ -188,9 +186,8 @@ EOF;
 
     /**
      * @covers \Sabre\VObject\Parser\MimeDir::readProperty
-     *
-     * @dataProvider provideBrokenVCalendar
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBrokenVCalendar')]
     public function testBrokenMultilineContentDoesNotBreakImportWhenSetToIgnoreBrokenLines(string $vcalendar): void
     {
         $mimeDir = new MimeDir(null, MimeDir::OPTION_IGNORE_INVALID_LINES);
@@ -201,10 +198,9 @@ EOF;
     /**
      * @covers \Sabre\VObject\Parser\MimeDir::readProperty
      *
-     * @dataProvider provideBrokenVCalendar
-     *
      * @param string $vcalendar
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBrokenVCalendar')]
     public function testBrokenMultilineContentDoesBreakImport($vcalendar): void
     {
         $mimeDir = new MimeDir();

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Parser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\ParseException;
@@ -109,7 +110,7 @@ VCF;
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideEmptyParserInput')]
+    #[DataProvider('provideEmptyParserInput')]
     public function testParseEmpty($input, $expectedExceptionMessage): void
     {
         $this->expectException(ParseException::class);
@@ -187,7 +188,7 @@ EOF;
     /**
      * @covers \Sabre\VObject\Parser\MimeDir::readProperty
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideBrokenVCalendar')]
+    #[DataProvider('provideBrokenVCalendar')]
     public function testBrokenMultilineContentDoesNotBreakImportWhenSetToIgnoreBrokenLines(string $vcalendar): void
     {
         $mimeDir = new MimeDir(null, MimeDir::OPTION_IGNORE_INVALID_LINES);
@@ -200,7 +201,7 @@ EOF;
      *
      * @param string $vcalendar
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideBrokenVCalendar')]
+    #[DataProvider('provideBrokenVCalendar')]
     public function testBrokenMultilineContentDoesBreakImport($vcalendar): void
     {
         $mimeDir = new MimeDir();

--- a/tests/VObject/Property/ICalendar/CalAddressTest.php
+++ b/tests/VObject/Property/ICalendar/CalAddressTest.php
@@ -6,9 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class CalAddressTest extends TestCase
 {
-    /**
-     * @dataProvider values
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('values')]
     public function testGetNormalizedValue(string $expected, string $input): void
     {
         $vobj = new \Sabre\VObject\Component\VCalendar();

--- a/tests/VObject/Property/ICalendar/CalAddressTest.php
+++ b/tests/VObject/Property/ICalendar/CalAddressTest.php
@@ -2,11 +2,12 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CalAddressTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('values')]
+    #[DataProvider('values')]
     public function testGetNormalizedValue(string $expected, string $input): void
     {
         $vobj = new \Sabre\VObject\Component\VCalendar();

--- a/tests/VObject/Property/VCard/DateAndOrTimeTest.php
+++ b/tests/VObject/Property/VCard/DateAndOrTimeTest.php
@@ -8,9 +8,7 @@ use Sabre\VObject\Reader;
 
 class DateAndOrTimeTest extends TestCase
 {
-    /**
-     * @dataProvider dates
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dates')]
     public function testGetJsonValue(string $input, string $output): void
     {
         $vcard = new VObject\Component\VCard();

--- a/tests/VObject/Property/VCard/DateAndOrTimeTest.php
+++ b/tests/VObject/Property/VCard/DateAndOrTimeTest.php
@@ -2,13 +2,14 @@
 
 namespace Sabre\VObject\Property\VCard;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject;
 use Sabre\VObject\Reader;
 
 class DateAndOrTimeTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('dates')]
+    #[DataProvider('dates')]
     public function testGetJsonValue(string $input, string $output): void
     {
         $vcard = new VObject\Component\VCard();

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject\Recur;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\VObject\InvalidDataException;
 
@@ -32,7 +33,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dst2HourlyTransitionProvider')]
+    #[DataProvider('dst2HourlyTransitionProvider')]
     public function test2HourlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -91,7 +92,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dst6HourlyTransitionProvider')]
+    #[DataProvider('dst6HourlyTransitionProvider')]
     public function testHourlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -283,7 +284,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dstDailyTransitionProvider')]
+    #[DataProvider('dstDailyTransitionProvider')]
     public function testDailyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -491,7 +492,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dstWeeklyTransitionProvider')]
+    #[DataProvider('dstWeeklyTransitionProvider')]
     public function testWeeklyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -744,7 +745,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dstMonthlyTransitionProvider')]
+    #[DataProvider('dstMonthlyTransitionProvider')]
     public function testMonthlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -1154,7 +1155,7 @@ class RRuleIteratorTest extends TestCase
     /**
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dstYearlyTransitionProvider')]
+    #[DataProvider('dstYearlyTransitionProvider')]
     public function testYearlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -1428,7 +1429,7 @@ class RRuleIteratorTest extends TestCase
      *
      * @param string[] $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('yearlyStartDateNotOnRRuleListProvider')]
+    #[DataProvider('yearlyStartDateNotOnRRuleListProvider')]
     public function testYearlyStartDateNotOnRRuleList(string $rule, string $start, array $expected): void
     {
         $this->parse($rule, $start, $expected);

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -29,6 +29,9 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dst2HourlyTransitionProvider')]
     public function test2HourlyOnDstTransition(string $start, array $expected): void
     {
@@ -85,6 +88,9 @@ class RRuleIteratorTest extends TestCase
         ];
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dst6HourlyTransitionProvider')]
     public function testHourlyOnDstTransition(string $start, array $expected): void
     {
@@ -274,6 +280,9 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dstDailyTransitionProvider')]
     public function testDailyOnDstTransition(string $start, array $expected): void
     {
@@ -479,6 +488,9 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dstWeeklyTransitionProvider')]
     public function testWeeklyOnDstTransition(string $start, array $expected): void
     {
@@ -729,6 +741,9 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dstMonthlyTransitionProvider')]
     public function testMonthlyOnDstTransition(string $start, array $expected): void
     {
@@ -1136,6 +1151,9 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     */
     #[\PHPUnit\Framework\Attributes\DataProvider('dstYearlyTransitionProvider')]
     public function testYearlyOnDstTransition(string $start, array $expected): void
     {
@@ -1407,6 +1425,8 @@ class RRuleIteratorTest extends TestCase
     /**
      * This caused an incorrect date to be returned by the rule iterator when
      * start date was not on the rrule list.
+     *
+     * @param string[] $expected
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('yearlyStartDateNotOnRRuleListProvider')]
     public function testYearlyStartDateNotOnRRuleList(string $rule, string $start, array $expected): void

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -29,9 +29,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dst2HourlyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dst2HourlyTransitionProvider')]
     public function test2HourlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -87,9 +85,7 @@ class RRuleIteratorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dst6HourlyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dst6HourlyTransitionProvider')]
     public function testHourlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -278,9 +274,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dstDailyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dstDailyTransitionProvider')]
     public function testDailyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -485,9 +479,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dstWeeklyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dstWeeklyTransitionProvider')]
     public function testWeeklyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -737,9 +729,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dstMonthlyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dstMonthlyTransitionProvider')]
     public function testMonthlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -1146,9 +1136,7 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dstYearlyTransitionProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dstYearlyTransitionProvider')]
     public function testYearlyOnDstTransition(string $start, array $expected): void
     {
         $this->parse(
@@ -1419,9 +1407,8 @@ class RRuleIteratorTest extends TestCase
     /**
      * This caused an incorrect date to be returned by the rule iterator when
      * start date was not on the rrule list.
-     *
-     * @dataProvider yearlyStartDateNotOnRRuleListProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('yearlyStartDateNotOnRRuleListProvider')]
     public function testYearlyStartDateNotOnRRuleList(string $rule, string $start, array $expected): void
     {
         $this->parse($rule, $start, $expected);

--- a/tests/VObject/TimeZoneUtilTest.php
+++ b/tests/VObject/TimeZoneUtilTest.php
@@ -11,9 +11,7 @@ class TimeZoneUtilTest extends TestCase
         TimeZoneUtil::clean();
     }
 
-    /**
-     * @dataProvider getMapping
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMapping')]
     public function testCorrectTZ(string $timezoneName): void
     {
         try {
@@ -163,9 +161,7 @@ HI;
         self::assertEquals($ex->getName(), $tz->getName());
     }
 
-    /**
-     * @dataProvider getPHPTimeZoneIdentifiers
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getPHPTimeZoneIdentifiers')]
     public function testTimeZoneIdentifiers(string $tzid): void
     {
         $tz = TimeZoneUtil::getTimeZone($tzid);
@@ -174,9 +170,7 @@ HI;
         self::assertEquals($ex->getName(), $tz->getName());
     }
 
-    /**
-     * @dataProvider getPHPTimeZoneBCIdentifiers
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getPHPTimeZoneBCIdentifiers')]
     public function testTimeZoneBCIdentifiers(string $tzid): void
     {
         /*

--- a/tests/VObject/TimeZoneUtilTest.php
+++ b/tests/VObject/TimeZoneUtilTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\VObject;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class TimeZoneUtilTest extends TestCase
@@ -11,7 +12,7 @@ class TimeZoneUtilTest extends TestCase
         TimeZoneUtil::clean();
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getMapping')]
+    #[DataProvider('getMapping')]
     public function testCorrectTZ(string $timezoneName): void
     {
         try {
@@ -161,7 +162,7 @@ HI;
         self::assertEquals($ex->getName(), $tz->getName());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getPHPTimeZoneIdentifiers')]
+    #[DataProvider('getPHPTimeZoneIdentifiers')]
     public function testTimeZoneIdentifiers(string $tzid): void
     {
         $tz = TimeZoneUtil::getTimeZone($tzid);
@@ -170,7 +171,7 @@ HI;
         self::assertEquals($ex->getName(), $tz->getName());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getPHPTimeZoneBCIdentifiers')]
+    #[DataProvider('getPHPTimeZoneBCIdentifiers')]
     public function testTimeZoneBCIdentifiers(string $tzid): void
     {
         /*

--- a/tests/VObject/TimezoneGuesser/FindFromTimezoneMapTest.php
+++ b/tests/VObject/TimezoneGuesser/FindFromTimezoneMapTest.php
@@ -11,9 +11,8 @@ class FindFromTimezoneMapTest extends TestCase
     /**
      * Verify that previously-deprecated IANA names have been replaced with
      * their canonical successors and resolve correctly.
-     *
-     * @dataProvider updatedTimezoneProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('updatedTimezoneProvider')]
     public function testUpdatedTimezonesResolve(string $mapKey, string $expectedOlson): void
     {
         $finder = new FindFromTimezoneMap();

--- a/tests/VObject/TimezoneGuesser/FindFromTimezoneMapTest.php
+++ b/tests/VObject/TimezoneGuesser/FindFromTimezoneMapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\VObject\TimezoneGuesser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FindFromTimezoneMapTest extends TestCase
@@ -12,7 +13,7 @@ class FindFromTimezoneMapTest extends TestCase
      * Verify that previously-deprecated IANA names have been replaced with
      * their canonical successors and resolve correctly.
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('updatedTimezoneProvider')]
+    #[DataProvider('updatedTimezoneProvider')]
     public function testUpdatedTimezonesResolve(string $mapKey, string $expectedOlson): void
     {
         $finder = new FindFromTimezoneMap();


### PR DESCRIPTION
Adjust the DataProvider test code to use Attribute rather than Annotation.

This happened in other sabre-io repos because `phpstan` is at a higher level, and I think that it adjusted this stuff.

`phpstan` is still at a low level in `Vobject`, so I used Rector rules:
```
    ->withRules([
        AddParamArrayDocblockFromDataProviderRector::class,
        DataProviderAnnotationToAttributeRector::class,
    ])
```

Note: when I tried to use Rector:
```
    ->withSets([
        // Includes sets leading up to and including PHPUnit 11
        PHPUnitSetList::PHPUNIT_100,
        PHPUnitSetList::PHPUNIT_110,
        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
    ])
```

It did things like putting the PHPunit assert calls back from static to dynamic calls. And then `phpstan` complained about that and wanted to put them back to static calls. So there is some conflict between what the Rector and `phpstan` rule sets think is "a good thing".
