### PR TITLE
ci: add PHP 8.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
             code-style: 'no'
             code-analysis: 'yes'
             rector-check: 'yes'
+          - php-versions: '8.6'
+            coverage: 'pcov'
+            code-style: 'no'
+            code-analysis: 'yes'
+            rector-check: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
             code-style: 'no'
             code-analysis: 'yes'
             rector-check: 'yes'
+          - php-versions: '8.6'
+            coverage: 'pcov'
+            code-style: 'no'
+            code-analysis: 'yes'
+            rector-check: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
leaving the other test matrices for PHP unchanged for now.

Run all CI checks on PHP 8.6.

This is just a draft PR to check that CI passes. When PHP 8.6 gets to the RC stage, then I will make a real PR to add 8.6.