### PR TITLE
Implement SECONDLY and MINUTELY recurrence frequencies

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -106,6 +106,14 @@ class RRuleIterator implements \Iterator
         // Otherwise, we find the next event in the normal RRULE
         // sequence.
         switch ($this->frequency) {
+            case 'secondly':
+                $this->nextSecondly();
+                break;
+
+            case 'minutely':
+                $this->nextMinutely();
+                break;
+
             case 'hourly':
                 $this->nextHourly();
                 break;
@@ -330,6 +338,62 @@ class RRuleIterator implements \Iterator
             $this->currentDate = $this->currentDate->sub(new \DateInterval('PT'.$this->hourJump.'H'));
             $this->hourJump = 0;
         }
+    }
+
+    /**
+     * Does the processing for advancing the iterator for secondly frequency.
+     */
+    protected function nextSecondly(): void
+    {
+        $this->advanceSubHourly('+'.$this->interval.' seconds', true);
+    }
+
+    /**
+     * Does the processing for advancing the iterator for minutely frequency.
+     */
+    protected function nextMinutely(): void
+    {
+        $this->advanceSubHourly('+'.$this->interval.' minutes', false);
+    }
+
+    /**
+     * Advances currentDate by a sub-hourly interval, applying the BYHOUR,
+     * BYMINUTE and (secondly only) BYSECOND limit rules of RFC 5545 §3.3.10.
+     */
+    protected function advanceSubHourly(string $interval, bool $limitBySecond): void
+    {
+        if (!$this->byHour && !$this->byMinute && !($limitBySecond && $this->bySecond)) {
+            $this->currentDate = $this->currentDate->modify($interval);
+
+            return;
+        }
+
+        do {
+            $this->currentDate = $this->currentDate->modify($interval);
+            if ($this->currentDate->getTimestamp() > self::dateUpperLimit) {
+                $this->currentDate = null;
+
+                return;
+            }
+        } while (!$this->matchesSubHourlyByRules($limitBySecond));
+    }
+
+    /**
+     * Whether currentDate satisfies the applicable BYHOUR/BYMINUTE/BYSECOND limits.
+     */
+    protected function matchesSubHourlyByRules(bool $limitBySecond): bool
+    {
+        if ($this->byHour && !in_array((int) $this->currentDate->format('G'), array_map('intval', $this->byHour), true)) {
+            return false;
+        }
+        if ($this->byMinute && !in_array((int) $this->currentDate->format('i'), array_map('intval', $this->byMinute), true)) {
+            return false;
+        }
+        if ($limitBySecond && $this->bySecond && !in_array((int) $this->currentDate->format('s'), array_map('intval', $this->bySecond), true)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -1620,6 +1620,132 @@ class RRuleIteratorTest extends TestCase
         );
     }
 
+    public function testMinutely(): void
+    {
+        $this->parse(
+            'FREQ=MINUTELY;COUNT=4',
+            '2024-01-01 09:00:00',
+            [
+                '2024-01-01 09:00:00',
+                '2024-01-01 09:01:00',
+                '2024-01-01 09:02:00',
+                '2024-01-01 09:03:00',
+            ]
+        );
+    }
+
+    public function testMinutelyInterval(): void
+    {
+        $this->parse(
+            'FREQ=MINUTELY;INTERVAL=15;COUNT=3',
+            '2024-01-01 09:50:00',
+            [
+                '2024-01-01 09:50:00',
+                '2024-01-01 10:05:00',
+                '2024-01-01 10:20:00',
+            ]
+        );
+    }
+
+    public function testMinutelyByHour(): void
+    {
+        $this->parse(
+            'FREQ=MINUTELY;BYHOUR=10;COUNT=3',
+            '2024-01-01 09:58:00',
+            [
+                '2024-01-01 09:58:00',
+                '2024-01-01 10:00:00',
+                '2024-01-01 10:01:00',
+            ]
+        );
+    }
+
+    public function testMinutelyByMinute(): void
+    {
+        $this->parse(
+            'FREQ=MINUTELY;BYMINUTE=0,30;COUNT=3',
+            '2024-01-01 09:58:00',
+            [
+                '2024-01-01 09:58:00',
+                '2024-01-01 10:00:00',
+                '2024-01-01 10:30:00',
+            ]
+        );
+    }
+
+    public function testSecondly(): void
+    {
+        $this->parse(
+            'FREQ=SECONDLY;COUNT=4',
+            '2024-01-01 09:00:00',
+            [
+                '2024-01-01 09:00:00',
+                '2024-01-01 09:00:01',
+                '2024-01-01 09:00:02',
+                '2024-01-01 09:00:03',
+            ]
+        );
+    }
+
+    public function testSecondlyByMinute(): void
+    {
+        $this->parse(
+            'FREQ=SECONDLY;BYMINUTE=0;COUNT=3',
+            '2024-01-01 08:59:58',
+            [
+                '2024-01-01 08:59:58',
+                '2024-01-01 09:00:00',
+                '2024-01-01 09:00:01',
+            ]
+        );
+    }
+
+    public function testSecondlyBySecond(): void
+    {
+        $this->parse(
+            'FREQ=SECONDLY;BYSECOND=0,30;COUNT=3',
+            '2024-01-01 08:59:58',
+            [
+                '2024-01-01 08:59:58',
+                '2024-01-01 09:00:00',
+                '2024-01-01 09:00:30',
+            ]
+        );
+    }
+
+    /**
+     * A bounded (UNTIL) sub-hourly rule must terminate. Before SECONDLY/MINUTELY
+     * were iterated, currentDate never advanced past the start, so valid() stayed
+     * true forever. The hard cap keeps a regression from hanging the suite.
+     */
+    public function testMinutelyUntilTerminates(): void
+    {
+        $parser = new RRuleIterator('FREQ=MINUTELY;UNTIL=20240101T091000Z', new \DateTime('2024-01-01 09:00:00', new \DateTimeZone('UTC')));
+        $result = [];
+        while ($parser->valid()) {
+            $result[] = $parser->current()->format('H:i:s');
+            if (count($result) > 100) {
+                self::fail('MINUTELY;UNTIL did not terminate');
+            }
+            $parser->next();
+        }
+        self::assertSame(['09:00:00', '09:01:00', '09:02:00', '09:03:00', '09:04:00', '09:05:00', '09:06:00', '09:07:00', '09:08:00', '09:09:00', '09:10:00'], $result);
+    }
+
+    public function testSecondlyUntilTerminates(): void
+    {
+        $parser = new RRuleIterator('FREQ=SECONDLY;UNTIL=20240101T090005Z', new \DateTime('2024-01-01 09:00:00', new \DateTimeZone('UTC')));
+        $result = [];
+        while ($parser->valid()) {
+            $result[] = $parser->current()->format('H:i:s');
+            if (count($result) > 100) {
+                self::fail('SECONDLY;UNTIL did not terminate');
+            }
+            $parser->next();
+        }
+        self::assertSame(['09:00:00', '09:00:01', '09:00:02', '09:00:03', '09:00:04', '09:00:05'], $result);
+    }
+
     public function parse($rule, string $start, array $expected, ?string $fastForward = null, string $tz = 'UTC', bool $runTillTheEnd = false): void
     {
         $dt = new \DateTime($start, new \DateTimeZone($tz));


### PR DESCRIPTION
`FREQ=SECONDLY` and `FREQ=MINUTELY` are accepted by `parseRRule()` and listed in the class docblock, but `next()` has no case for either and no `nextSecondly()`/`nextMinutely()` exists, so `currentDate` never advances. Two results on ordinary valid input:

- `FREQ=MINUTELY;COUNT=4` returns four copies of the start instead of minute-spaced instants.
- `FREQ=MINUTELY;UNTIL=...` loops forever — `valid()` stays true while `currentDate` never passes `until`. Same for `SECONDLY`.

Both methods advance by the interval and apply the BYHOUR/BYMINUTE limits (plus BYSECOND for secondly), mirroring the `do/while` filtering `nextDaily()` already uses; the `dateUpperLimit` guard stops an unsatisfiable BY combination from hanging.

This covers the LIMIT rules for these two frequencies (RFC 5545 §3.3.10). The EXPAND cases are left as follow-up: BYSECOND under MINUTELY, and BYMINUTE/BYSECOND under HOURLY and coarser frequencies (which is why `FREQ=HOURLY;BYMINUTE=0,30` still yields one instance per hour) — those need an expansion pass the iterator doesn't have yet.

Tests cover COUNT- and UNTIL-bounded cases for both frequencies, INTERVAL, and the BYHOUR/BYMINUTE/BYSECOND limits; the UNTIL tests are capped so they can't hang.