### PR TITLE
fix: repair --format help text in CLI

### DIFF
--- a/lib/Cli.php
+++ b/lib/Cli.php
@@ -214,8 +214,9 @@ class Cli
         $this->log($this->colorize('green', '  -q            ')."Don't output anything.");
         $this->log($this->colorize('green', '  -help -h      ').'Display this help message.');
         $this->log($this->colorize('green', '  --format      ').'Convert to a specific format. Must be one of: vcard, vcard21,');
+        $this->log('                vcard30, vcard40, icalendar, icalendar20, jcal, jcard, json,');
+        $this->log('                mimedir.');
         $this->log($this->colorize('green', '  --forgiving   ').'Makes the parser less strict.');
-        $this->log('                vcard30, vcard40, icalendar20, jcal, jcard, json, mimedir.');
         $this->log($this->colorize('green', '  --inputformat ').'If the input format cannot be guessed from the extension, it');
         $this->log('                must be specified here.');
         $this->log($this->colorize('green', '  --pretty      ').'json pretty-print.');


### PR DESCRIPTION
_Disclosure: this patch was prepared with AI assistance (Claude Opus 5). I checked the `match` arms and traced the print order in `showHelp()` myself before opening this._

### Problem

Two things are off in the `--format` entry of `vobject --help`.

**The description is split in half by another option.** `showHelp()` prints line by line, and the continuation of the format list sits after the `--forgiving` line, so the actual output reads:

```
  --format      Convert to a specific format. Must be one of: vcard, vcard21,
  --forgiving   Makes the parser less strict.
                vcard30, vcard40, icalendar20, jcal, jcard, json, mimedir.
```

**One accepted value is missing.** The `format` case in `parseArguments()` accepts ten values:

```php
$this->format = match ($value) {
    'jcard', 'jcal', 'vcard21', 'vcard30', 'vcard40', 'icalendar20', 'json', 'mimedir', 'icalendar', 'vcard' => $value,
    default => throw new \InvalidArgumentException('Unknown format: '.$value),
};
```

The help text lists nine — `icalendar` (without the `20` suffix) is absent, even though `--format=icalendar` works.

### Fix

Move the continuation lines back under `--format` and add `icalendar`. The list now needs three lines to stay inside the same width as the surrounding entries, so it wraps onto `mimedir.` rather than being crammed in.

Resulting output:

```
  --format      Convert to a specific format. Must be one of: vcard, vcard21,
                vcard30, vcard40, icalendar, icalendar20, jcal, jcard, json,
                mimedir.
  --forgiving   Makes the parser less strict.
```

Help text only — no behaviour change.
