### PR TITLE
Do not escape commas in Uri values

### DIFF
--- a/lib/Property/Uri.php
+++ b/lib/Property/Uri.php
@@ -91,11 +91,9 @@ class Uri extends Text
     public function getRawMimeDirValue(): string
     {
         if (is_array($this->value)) {
-            $value = $this->value[0];
+            return $this->value[0];
         } else {
-            $value = $this->value;
+            return $this->value;
         }
-
-        return strtr($value, [',' => '\,']);
     }
 }

--- a/lib/Property/Uri.php
+++ b/lib/Property/Uri.php
@@ -92,8 +92,8 @@ class Uri extends Text
     {
         if (is_array($this->value)) {
             return $this->value[0];
-        } else {
-            return $this->value;
         }
+
+        return $this->value;
     }
 }

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2126,10 +2126,10 @@ XML,
      */
     public function testRFC6350Section6Part5Part2(): void
     {
-    /*
-     * Note: We do not expect the comma in the Uri value of the GEO property to
-     * be escaped
-     */
+        /*
+         * Note: We do not expect the comma in the Uri value of the GEO property to
+         * be escaped
+         */
         self::assertXMLEqualsToMimeDir(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2126,6 +2126,10 @@ XML,
      */
     public function testRFC6350Section6Part5Part2(): void
     {
+    /*
+     * Note: We do not expect the comma in the Uri value of the GEO property to
+     * be escaped
+     */
         self::assertXMLEqualsToMimeDir(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -2139,7 +2143,7 @@ XML,
 XML,
             'BEGIN:VCARD'."\n".
             'VERSION:4.0'."\n".
-            'GEO:geo:37.386013\,-122.082932'."\n".
+            'GEO:geo:37.386013,-122.082932'."\n".
             'END:VCARD'."\n"
         );
 

--- a/tests/VObject/Property/UriTest.php
+++ b/tests/VObject/Property/UriTest.php
@@ -26,12 +26,12 @@ ICS;
 
     public function testNoEscapeForDataValue()
     {
-        $input = <<<VCARD
-BEGIN:VCARD
-VERSION:4.0
-PHOTO;VALUE=URI:data:image/jpeg;base64,MIICajCCAd
-END:VCARD
-VCARD;
+        $input = <<<VCARD_WRAP
+        BEGIN:VCARD
+        VERSION:4.0
+        PHOTO;VALUE=URI:data:image/jpeg;base64,MIICajCCAd
+        END:VCARD
+        VCARD_WRAP;
         $vObject = Reader::read($input);
         self::assertStringContainsString('data:image/jpeg;base64,MIICajCCAd',
             $vObject->PHOTO->serialize(),

--- a/tests/VObject/Property/UriTest.php
+++ b/tests/VObject/Property/UriTest.php
@@ -23,4 +23,17 @@ ICS;
         $output = Reader::read($input)->serialize();
         self::assertStringContainsString('URL;VALUE=URI:http://example.org/', $output);
     }
+
+    public function testNoEscapeForDataValue() {
+        $input = <<<VCARD
+BEGIN:VCARD
+VERSION:4.0
+PHOTO;VALUE=URI:data:image/jpeg;base64,MIICajCCAd
+END:VCARD
+VCARD;
+	    $vObject = Reader::read($input);
+	    self::assertStringContainsString("data:image/jpeg;base64,MIICajCCAd",
+					      $vObject->PHOTO->serialize(),
+					      "Comma is not escaped");
+	}
 }

--- a/tests/VObject/Property/UriTest.php
+++ b/tests/VObject/Property/UriTest.php
@@ -24,16 +24,17 @@ ICS;
         self::assertStringContainsString('URL;VALUE=URI:http://example.org/', $output);
     }
 
-    public function testNoEscapeForDataValue() {
+    public function testNoEscapeForDataValue()
+    {
         $input = <<<VCARD
 BEGIN:VCARD
 VERSION:4.0
 PHOTO;VALUE=URI:data:image/jpeg;base64,MIICajCCAd
 END:VCARD
 VCARD;
-	    $vObject = Reader::read($input);
-	    self::assertStringContainsString("data:image/jpeg;base64,MIICajCCAd",
-					      $vObject->PHOTO->serialize(),
-					      "Comma is not escaped");
-	}
+        $vObject = Reader::read($input);
+        self::assertStringContainsString('data:image/jpeg;base64,MIICajCCAd',
+            $vObject->PHOTO->serialize(),
+            'Comma is not escaped');
+    }
 }


### PR DESCRIPTION
Uri values, as found in PHOTO and GEO properties, should not have comma escaped. An example of a valid PHOTO property can be seen here: https://datatracker.ietf.org/doc/html/rfc6350#section-6.2.4.

As a result of this change, I had to modify an existing testcase that uses a Uri value with geo: scheme.